### PR TITLE
[Feat] 핵심 도메인 엔티티(Entity) 및 공통 BaseEntity 구현

### DIFF
--- a/roddy/src/main/java/com/roddy/RoddyApplication.java
+++ b/roddy/src/main/java/com/roddy/RoddyApplication.java
@@ -2,7 +2,9 @@ package com.roddy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class RoddyApplication {
 

--- a/roddy/src/main/java/com/roddy/domain/BaseEntity.java
+++ b/roddy/src/main/java/com/roddy/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.roddy.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/roddy/src/main/java/com/roddy/domain/Comment.java
+++ b/roddy/src/main/java/com/roddy/domain/Comment.java
@@ -38,7 +38,8 @@ public class Comment extends BaseEntity {
     @PrePersist
     @PreUpdate
     public void validateParentPost() {
-        if (parent != null && !parent.getPost().equals(this.post)) {
+        // 객체(Proxy) 비교가 아닌, 실제 식별자(ID) 값을 비교하도록 수정
+        if (parent != null && !parent.getPost().getId().equals(this.post.getId())) {
             throw new IllegalStateException("대댓글은 부모 댓글과 같은 게시글에만 작성할 수 있습니다.");
         }
     }

--- a/roddy/src/main/java/com/roddy/domain/Comment.java
+++ b/roddy/src/main/java/com/roddy/domain/Comment.java
@@ -1,0 +1,33 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comments")
+public class Comment extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user; // 댓글 작성자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post; // 어느 게시글의 댓글인지
+
+    // 대댓글용 (부모 댓글 참조, 기존 comment_id2 컬럼)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+}

--- a/roddy/src/main/java/com/roddy/domain/Comment.java
+++ b/roddy/src/main/java/com/roddy/domain/Comment.java
@@ -5,29 +5,41 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 커뮤니티 게시글의 댓글 및 대댓글 정보를 관리하는 엔티티입니다.
+ */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "comments")
-public class Comment extends BaseEntity{
+public class Comment extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
     private Long id;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user; // 댓글 작성자
+    // optional = false 와 nullable = false 로 필수 연관관계 강제
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private Post post; // 어느 게시글의 댓글인지
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
 
-    // 대댓글용 (부모 댓글 참조, 기존 comment_id2 컬럼)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Comment parent;
+
+    // 엔티티가 저장/수정되기 전에 데이터 정합성을 검증합니다.
+    @PrePersist
+    @PreUpdate
+    public void validateParentPost() {
+        if (parent != null && !parent.getPost().equals(this.post)) {
+            throw new IllegalStateException("대댓글은 부모 댓글과 같은 게시글에만 작성할 수 있습니다.");
+        }
+    }
 }

--- a/roddy/src/main/java/com/roddy/domain/Company.java
+++ b/roddy/src/main/java/com/roddy/domain/Company.java
@@ -5,11 +5,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 채용 공고를 등록하는 기업 정보를 관리하는 엔티티입니다.
+ */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "companies")
-public class Company {
+public class Company extends BaseEntity{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "company_id")

--- a/roddy/src/main/java/com/roddy/domain/Company.java
+++ b/roddy/src/main/java/com/roddy/domain/Company.java
@@ -1,0 +1,21 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "companies")
+public class Company {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "company_id")
+    private Long id;
+
+    private String name; // 기존 Field
+
+    private String description; // 기존 Field2 (설명이나 산업군 등)
+}

--- a/roddy/src/main/java/com/roddy/domain/JobCompetency.java
+++ b/roddy/src/main/java/com/roddy/domain/JobCompetency.java
@@ -1,0 +1,29 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "job_competencies")
+public class JobCompetency extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "job_analysis_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id")
+    private JobPosting jobPosting;
+
+    // Field1 ~ 6에 해당하는 역량 기준 점수들
+    private Integer requiredDataModeling;
+    private Integer requiredArchitecture;
+    private Integer requiredScalability;
+    private Integer requiredStability;
+    private Integer requiredDevops;
+    private Integer requiredMonitoring;
+}

--- a/roddy/src/main/java/com/roddy/domain/JobPosting.java
+++ b/roddy/src/main/java/com/roddy/domain/JobPosting.java
@@ -32,5 +32,13 @@ public class JobPosting extends BaseEntity{
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 
+    @PrePersist
+    @PreUpdate
+    public void validateDates() {
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            throw new IllegalStateException("채용 시작일은 종료일보다 이전이어야 합니다.");
+        }
+    }
+
     private String jobCategory; // 인턴/신입/경력직
 }

--- a/roddy/src/main/java/com/roddy/domain/JobPosting.java
+++ b/roddy/src/main/java/com/roddy/domain/JobPosting.java
@@ -1,0 +1,36 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "job_postings")
+public class JobPosting extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "job_id")
+    private Long id;
+
+    private String title;
+
+    private String recruitField; // 채용 분야
+
+    @Column(columnDefinition = "TEXT")
+    private String content; // 채용 본문 내용
+
+    // 하나의 기업은 여러 채용공고를 가질 수 있으므로 N:1 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id")
+    private Company company;
+
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    private String jobCategory; // 인턴/신입/경력직
+}

--- a/roddy/src/main/java/com/roddy/domain/Post.java
+++ b/roddy/src/main/java/com/roddy/domain/Post.java
@@ -1,0 +1,29 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "posts")
+public class Post extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user; // 작성자
+
+    private Integer viewCount;
+}

--- a/roddy/src/main/java/com/roddy/domain/Stack.java
+++ b/roddy/src/main/java/com/roddy/domain/Stack.java
@@ -1,0 +1,22 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "stacks")
+public class Stack {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stack_id")
+    private Long id;
+
+    private String name; // 예: Java, Spring Boot, MySQL
+
+    // 1. Data Modeling, 2. Architecture 등
+    private String category;
+}

--- a/roddy/src/main/java/com/roddy/domain/Study.java
+++ b/roddy/src/main/java/com/roddy/domain/Study.java
@@ -1,0 +1,24 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "studies")
+public class Study extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_id")
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private Integer recruitNum; // 모집 인원
+}

--- a/roddy/src/main/java/com/roddy/domain/StudyMember.java
+++ b/roddy/src/main/java/com/roddy/domain/StudyMember.java
@@ -9,7 +9,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "study_members")
+@Table(name = "study_members", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_study_member", columnNames = {"user_id", "study_id"})
+})
 public class StudyMember extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,11 +19,11 @@ public class StudyMember extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_id")
+    @JoinColumn(name = "study_id", nullable = false)
     private Study study;
 
     // 대기중, 승인됨, 거절됨 등 상태 관리

--- a/roddy/src/main/java/com/roddy/domain/StudyMember.java
+++ b/roddy/src/main/java/com/roddy/domain/StudyMember.java
@@ -1,0 +1,30 @@
+package com.roddy.domain;
+
+import com.roddy.domain.enums.StudyMemberStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_members")
+public class StudyMember extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    // 대기중, 승인됨, 거절됨 등 상태 관리
+    @Enumerated(EnumType.STRING)
+    private StudyMemberStatus status;
+}

--- a/roddy/src/main/java/com/roddy/domain/User.java
+++ b/roddy/src/main/java/com/roddy/domain/User.java
@@ -1,0 +1,48 @@
+package com.roddy.domain;
+
+import com.roddy.domain.enums.ExperienceLevel;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String loginId;
+    private String nickname;
+    private String userName;
+    private String phone;
+    private String email;
+    private String profileImageUrl;
+    private Integer age;
+    private String portfolioUrl;
+
+    // 경력 연차 (신입/경력 등을 나누기 위해 Enum 사용 권장)
+    @Enumerated(EnumType.STRING)
+    private ExperienceLevel experienceYears;
+
+    private String githubUrl;
+
+    // 소셜 로그인 제공자 (GOOGLE, KAKAO 등)
+    private String socialProvider;
+
+    // 희망 직무
+    private String targetField;
+
+    @Builder
+    public User(String loginId, String nickname, String email, ExperienceLevel experienceYears) {
+        this.loginId = loginId;
+        this.nickname = nickname;
+        this.email = email;
+        this.experienceYears = experienceYears;
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/User.java
+++ b/roddy/src/main/java/com/roddy/domain/User.java
@@ -17,11 +17,15 @@ public class User extends BaseEntity{
     @Column(name = "user_id")
     private Long id;
 
+    @Column(nullable = false, unique = true)
     private String loginId;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
     private String nickname;
     private String userName;
     private String phone;
-    private String email;
     private String profileImageUrl;
     private Integer age;
     private String portfolioUrl;

--- a/roddy/src/main/java/com/roddy/domain/UserAnalysis.java
+++ b/roddy/src/main/java/com/roddy/domain/UserAnalysis.java
@@ -1,0 +1,28 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_analyses")
+public class UserAnalysis extends BaseEntity { // createdAt을 lastAnalyzedAt 대신 사용 가능
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_analysis_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Integer dataModelingScore;
+    private Integer architectureScore;
+    private Integer scalabilityScore;
+    private Integer stabilityScore;
+    private Integer devopsScore;
+    private Integer monitoringScore;
+}

--- a/roddy/src/main/java/com/roddy/domain/UserAnalysis.java
+++ b/roddy/src/main/java/com/roddy/domain/UserAnalysis.java
@@ -15,8 +15,8 @@ public class UserAnalysis extends BaseEntity { // createdAtÏùÑ lastAnalyzedAt Îå
     @Column(name = "user_analysis_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
     private User user;
 
     private Integer dataModelingScore;

--- a/roddy/src/main/java/com/roddy/domain/UserScrapJob.java
+++ b/roddy/src/main/java/com/roddy/domain/UserScrapJob.java
@@ -1,0 +1,25 @@
+package com.roddy.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_scrap_jobs")
+public class UserScrapJob extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "scrap_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id")
+    private JobPosting jobPosting;
+}

--- a/roddy/src/main/java/com/roddy/domain/UserScrapJob.java
+++ b/roddy/src/main/java/com/roddy/domain/UserScrapJob.java
@@ -8,7 +8,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user_scrap_jobs")
+@Table(name = "user_scrap_jobs", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_scrap", columnNames = {"user_id", "job_id"})
+})
 public class UserScrapJob extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -16,10 +18,10 @@ public class UserScrapJob extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_id")
+    @JoinColumn(name = "job_id", nullable = false)
     private JobPosting jobPosting;
 }

--- a/roddy/src/main/java/com/roddy/domain/UserStack.java
+++ b/roddy/src/main/java/com/roddy/domain/UserStack.java
@@ -1,0 +1,30 @@
+package com.roddy.domain;
+
+import com.roddy.domain.enums.StackLevel;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_stacks")
+public class UserStack extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_stack_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stack_id")
+    private Stack stack;
+
+    // 숙련도 (1~5 점수 또는 HIGH/MIDDLE/LOW)
+    @Enumerated(EnumType.STRING)
+    private StackLevel stackLevel;
+}

--- a/roddy/src/main/java/com/roddy/domain/UserStack.java
+++ b/roddy/src/main/java/com/roddy/domain/UserStack.java
@@ -9,7 +9,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user_stacks")
+@Table(name = "user_stacks", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_stack", columnNames = {"user_id", "stack_id"})
+})
 public class UserStack extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,14 +19,14 @@ public class UserStack extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "stack_id")
+    @JoinColumn(name = "stack_id", nullable = false)
     private Stack stack;
 
-    // 숙련도 (1~5 점수 또는 HIGH/MIDDLE/LOW)
+    // 숙련도
     @Enumerated(EnumType.STRING)
     private StackLevel stackLevel;
 }

--- a/roddy/src/main/java/com/roddy/domain/enums/ExperienceLevel.java
+++ b/roddy/src/main/java/com/roddy/domain/enums/ExperienceLevel.java
@@ -1,0 +1,15 @@
+package com.roddy.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExperienceLevel {
+    NEWBIE("신입"),
+    JUNIOR("1~3년차"),
+    MIDDLE("4~7년차"),
+    SENIOR("8년차 이상");
+
+    private final String description;
+}

--- a/roddy/src/main/java/com/roddy/domain/enums/StackLevel.java
+++ b/roddy/src/main/java/com/roddy/domain/enums/StackLevel.java
@@ -1,0 +1,15 @@
+package com.roddy.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StackLevel {
+    BEGINNER("초급 (기초 문법 및 개념 이해)"),
+    INTERMEDIATE("중급 (실무 적용 및 문제 해결 가능)"),
+    ADVANCED("고급 (아키텍처 설계 및 성능 최적화 가능)"),
+    EXPERT("전문가 (기술 리딩 및 코어 트러블슈팅 가능)");
+
+    private final String description;
+}

--- a/roddy/src/main/java/com/roddy/domain/enums/StudyMemberStatus.java
+++ b/roddy/src/main/java/com/roddy/domain/enums/StudyMemberStatus.java
@@ -1,0 +1,14 @@
+package com.roddy.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StudyMemberStatus {
+    PENDING("승인 대기중"),
+    APPROVED("참여 승인됨"),
+    REJECTED("참여 거절됨");
+
+    private final String description;
+}

--- a/roddy/src/main/resources/application.yaml
+++ b/roddy/src/main/resources/application.yaml
@@ -1,20 +1,41 @@
 spring:
   application:
     name: roddy
+  profiles:
+    active: local # 기본 실행 환경을 local로 지정
 
+---
+# [Local 환경 설정] - 개발자 PC에서 켤 때
+spring:
+  config:
+    activate:
+      on-profile: local
   datasource:
-    url: jdbc:mysql://localhost:3306/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/${DB_NAME:roddy}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
-    password: ${DB_PASSWORD}
+    password: ${DB_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: update
-    show-sql: true
+      ddl-auto: update # 개발 환경이므로 엔티티 변경 시 DB 자동 수정 허용
+    show-sql: true # SQL 로그 출력 (개발 중 디버깅 용도)
     properties:
       hibernate:
         format_sql: true
 
-server:
-  port: 8080
+---
+# [Prod 환경 설정] - 나중에 실제 AWS 서버에 배포할 때
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: jdbc:mysql://${AWS_DB_URL}/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: ${AWS_DB_USERNAME}
+    password: ${AWS_DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate # 운영 서버는 테이블을 절대 건드리지 않고, 맞게 생성되어 있는지만 검증!
+    show-sql: false # 운영 서버 성능 저하 및 보안 이슈 방지를 위해 로그 끄기

--- a/roddy/src/main/resources/application.yaml
+++ b/roddy/src/main/resources/application.yaml
@@ -3,18 +3,18 @@ spring:
     name: roddy
 
   datasource:
-    url: jdbc:mysql://localhost:3306/roddy?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
-    password: root
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-    jpa:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
       hibernate:
-        ddl-auto: update
-      show-sql: true
-      properties:
-        hibernate:
-          format_sql: true
+        format_sql: true
 
-  server:
-    port: 8080
+server:
+  port: 8080


### PR DESCRIPTION
- 공통 생성일/수정일 관리를 위한 BaseEntity 구현 및 JPA Auditing 설정
- 사용자(User), 기업(Company), 채용공고(JobPosting) 엔티티 생성 및 연관관계 매핑
- 커뮤니티(Post, Comment), 스터디(Study) 엔티티 및 대댓글 자기참조 구조 설계
- 기술 스택 및 유저 분석 결과 관리를 위한 매핑 엔티티 추가
- StackLevel, ExperienceLevel, StudyMemberStatus 등 Enum 클래스 설계 및 description 필드 추가
- 팀 DB 네이밍 컨벤션(snake_case, 복수형 테이블명) 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job postings, company profiles, and job competency details.
  * User profiles with experience levels, skill stacks, and skill scoring.
  * Study groups with membership management and statuses.
  * Posts and threaded comments with parent/child validation.
  * Ability to bookmark job postings and track post view counts.
  * Automatic tracking of creation and update timestamps across entities.

* **Chores**
  * Configuration moved to profile-based environment settings (local/prod).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->