### PR TITLE
[Feat] 카카오/구글 소셜 로그인 REST API 추가 (#16)

### DIFF
--- a/roddy/src/main/java/com/roddy/domain/auth/controller/AuthController.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/controller/AuthController.java
@@ -4,9 +4,12 @@ import com.roddy.domain.auth.dto.request.LoginRequest;
 import com.roddy.domain.auth.dto.request.LogoutRequest;
 import com.roddy.domain.auth.dto.request.ReissueTokenRequest;
 import com.roddy.domain.auth.dto.request.SignupRequest;
+import com.roddy.domain.auth.dto.request.SocialLoginRequest;
 import com.roddy.domain.auth.dto.response.LoginResponse;
 import com.roddy.domain.auth.dto.response.ReissueTokenResponse;
+import com.roddy.domain.auth.dto.response.SocialLoginResponse;
 import com.roddy.domain.auth.service.AuthService;
+import com.roddy.domain.auth.service.SocialAuthService;
 import com.roddy.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final SocialAuthService socialAuthService;
 
     @PostMapping("/signup")
     @Operation(
@@ -55,6 +59,34 @@ public class AuthController {
     })
     public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         return ApiResponse.onSuccess("로그인이 완료되었습니다.", authService.login(request));
+    }
+
+    @PostMapping("/google")
+    @Operation(
+            summary = "구글 소셜 로그인",
+            description = "프론트에서 발급받은 구글 액세스 토큰으로 사용자 정보를 조회한 뒤 Roddy 토큰과 사용자 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이메일 미동의 또는 다른 로그인 방식으로 가입된 계정", content = @Content(schema = @Schema())),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 구글 액세스 토큰", content = @Content(schema = @Schema()))
+    })
+    public ApiResponse<SocialLoginResponse> googleLogin(@Valid @RequestBody SocialLoginRequest request) {
+        return ApiResponse.onSuccess("구글 로그인이 완료되었습니다.", socialAuthService.loginWithGoogle(request.accessToken()));
+    }
+
+    @PostMapping("/kakao")
+    @Operation(
+            summary = "카카오 소셜 로그인",
+            description = "프론트에서 발급받은 카카오 액세스 토큰으로 사용자 정보를 조회한 뒤 Roddy 토큰과 사용자 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이메일 미동의 또는 다른 로그인 방식으로 가입된 계정", content = @Content(schema = @Schema())),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 액세스 토큰", content = @Content(schema = @Schema()))
+    })
+    public ApiResponse<SocialLoginResponse> kakaoLogin(@Valid @RequestBody SocialLoginRequest request) {
+        return ApiResponse.onSuccess("카카오 로그인이 완료되었습니다.", socialAuthService.loginWithKakao(request.accessToken()));
     }
 
     @PostMapping("/reissue")

--- a/roddy/src/main/java/com/roddy/domain/auth/controller/AuthController.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/controller/AuthController.java
@@ -69,7 +69,8 @@ public class AuthController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구글 로그인 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이메일 미동의 또는 다른 로그인 방식으로 가입된 계정", content = @Content(schema = @Schema())),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 구글 액세스 토큰", content = @Content(schema = @Schema()))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 구글 액세스 토큰", content = @Content(schema = @Schema())),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "504", description = "구글 사용자 정보 조회 타임아웃", content = @Content(schema = @Schema()))
     })
     public ApiResponse<SocialLoginResponse> googleLogin(@Valid @RequestBody SocialLoginRequest request) {
         return ApiResponse.onSuccess("구글 로그인이 완료되었습니다.", socialAuthService.loginWithGoogle(request.accessToken()));
@@ -83,7 +84,8 @@ public class AuthController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 로그인 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이메일 미동의 또는 다른 로그인 방식으로 가입된 계정", content = @Content(schema = @Schema())),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 액세스 토큰", content = @Content(schema = @Schema()))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 액세스 토큰", content = @Content(schema = @Schema())),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "504", description = "카카오 사용자 정보 조회 타임아웃", content = @Content(schema = @Schema()))
     })
     public ApiResponse<SocialLoginResponse> kakaoLogin(@Valid @RequestBody SocialLoginRequest request) {
         return ApiResponse.onSuccess("카카오 로그인이 완료되었습니다.", socialAuthService.loginWithKakao(request.accessToken()));

--- a/roddy/src/main/java/com/roddy/domain/auth/dto/request/SocialLoginRequest.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/dto/request/SocialLoginRequest.java
@@ -1,0 +1,8 @@
+package com.roddy.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SocialLoginRequest(
+        @NotBlank String accessToken
+) {
+}

--- a/roddy/src/main/java/com/roddy/domain/auth/dto/response/SocialLoginResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/dto/response/SocialLoginResponse.java
@@ -1,0 +1,26 @@
+package com.roddy.domain.auth.dto.response;
+
+import com.roddy.domain.auth.entity.User;
+
+public record SocialLoginResponse(
+        String accessToken,
+        String refreshToken,
+        boolean isOnboard,
+        boolean githubConnected,
+        SocialLoginUserResponse user
+) {
+
+    public static SocialLoginResponse from(LoginResponse loginResponse, User user) {
+        return new SocialLoginResponse(
+                loginResponse.accessToken(),
+                loginResponse.refreshToken(),
+                loginResponse.isOnboard(),
+                loginResponse.githubConnected(),
+                new SocialLoginUserResponse(
+                        String.valueOf(user.getId()),
+                        user.getEmail(),
+                        user.getNickname()
+                )
+        );
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/auth/dto/response/SocialLoginUserResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/dto/response/SocialLoginUserResponse.java
@@ -1,0 +1,8 @@
+package com.roddy.domain.auth.dto.response;
+
+public record SocialLoginUserResponse(
+        String id,
+        String email,
+        String nickname
+) {
+}

--- a/roddy/src/main/java/com/roddy/domain/auth/entity/User.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/entity/User.java
@@ -18,7 +18,15 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "users")
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_users_social_type_social_id", columnList = "social_type, social_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_users_social_type_social_id", columnNames = {"social_type", "social_id"})
+        }
+)
 public class User extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -154,6 +162,10 @@ public class User extends BaseEntity {
             this.age = age;
         }
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void linkSocialId(String socialId) {
+        this.socialId = socialId;
     }
 
     public void withdraw() {

--- a/roddy/src/main/java/com/roddy/domain/auth/repository/UserRepository.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.roddy.domain.auth.repository;
 
 import com.roddy.domain.auth.entity.User;
+import com.roddy.domain.enums.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -12,6 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
     Optional<User> findByIdAndDeletedAtIsNull(Long id);
+
+    Optional<User> findBySocialTypeAndSocialIdAndDeletedAtIsNull(SocialType socialType, String socialId);
 
     boolean existsByEmail(String email);
 }

--- a/roddy/src/main/java/com/roddy/domain/auth/security/CustomOAuth2User.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/security/CustomOAuth2User.java
@@ -25,6 +25,11 @@ public record CustomOAuth2User(
 
     @Override
     public String getName() {
-        return String.valueOf(attributes.getOrDefault("sub", user.getEmail()));
+        return String.valueOf(
+                attributes.getOrDefault(
+                        "sub",
+                        attributes.getOrDefault("id", user.getEmail())
+                )
+        );
     }
 }

--- a/roddy/src/main/java/com/roddy/domain/auth/security/CustomOAuth2User.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/security/CustomOAuth2User.java
@@ -25,11 +25,16 @@ public record CustomOAuth2User(
 
     @Override
     public String getName() {
-        return String.valueOf(
-                attributes.getOrDefault(
-                        "sub",
-                        attributes.getOrDefault("id", user.getEmail())
-                )
-        );
+        Object sub = attributes.get("sub");
+        if (sub != null) {
+            return String.valueOf(sub);
+        }
+
+        Object id = attributes.get("id");
+        if (id != null) {
+            return String.valueOf(id);
+        }
+
+        return user.getEmail();
     }
 }

--- a/roddy/src/main/java/com/roddy/domain/auth/service/SocialAuthService.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/service/SocialAuthService.java
@@ -1,0 +1,294 @@
+package com.roddy.domain.auth.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.roddy.domain.auth.dto.response.LoginResponse;
+import com.roddy.domain.auth.dto.response.SocialLoginResponse;
+import com.roddy.domain.auth.entity.User;
+import com.roddy.domain.auth.repository.UserRepository;
+import com.roddy.domain.enums.SocialType;
+import com.roddy.global.apiPayload.code.GeneralErrorCode;
+import com.roddy.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+@Service
+@RequiredArgsConstructor
+public class SocialAuthService {
+
+    private static final Duration SOCIAL_API_TIMEOUT = Duration.ofSeconds(5);
+    private static final String GOOGLE_BASE_URL = "https://openidconnect.googleapis.com";
+    private static final String KAKAO_BASE_URL = "https://kapi.kakao.com";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthService authService;
+
+    private final WebClient googleWebClient = WebClient.builder()
+            .baseUrl(GOOGLE_BASE_URL)
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .defaultHeader(HttpHeaders.USER_AGENT, "roddy-backend")
+            .build();
+
+    private final WebClient kakaoWebClient = WebClient.builder()
+            .baseUrl(KAKAO_BASE_URL)
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .defaultHeader(HttpHeaders.USER_AGENT, "roddy-backend")
+            .build();
+
+    @Transactional
+    public SocialLoginResponse loginWithGoogle(String providerAccessToken) {
+        GoogleUserInfo googleUserInfo = fetchGoogleUserInfo(providerAccessToken);
+
+        if (googleUserInfo.email() == null || googleUserInfo.sub() == null) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_TOKEN,
+                    "구글 사용자 정보를 불러오지 못했습니다."
+            );
+        }
+
+        if (!Boolean.TRUE.equals(googleUserInfo.emailVerified())) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_PARAMETER,
+                    "이메일 인증이 완료된 구글 계정만 사용할 수 있습니다."
+            );
+        }
+
+        User user = resolveOrCreateSocialUser(
+                SocialType.GOOGLE,
+                googleUserInfo.sub(),
+                googleUserInfo.email(),
+                defaultDisplayName(googleUserInfo.name(), googleUserInfo.email())
+        );
+
+        LoginResponse loginResponse = authService.issueTokens(user);
+        return SocialLoginResponse.from(loginResponse, user);
+    }
+
+    @Transactional
+    public SocialLoginResponse loginWithKakao(String providerAccessToken) {
+        KakaoUserInfo kakaoUserInfo = fetchKakaoUserInfo(providerAccessToken);
+        KakaoAccount kakaoAccount = kakaoUserInfo.kakaoAccount();
+
+        String email = kakaoAccount == null ? null : kakaoAccount.email();
+        String socialId = kakaoUserInfo.id() == null ? null : String.valueOf(kakaoUserInfo.id());
+
+        if (email == null || socialId == null) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_PARAMETER,
+                    "카카오 계정 이메일 제공 동의가 필요합니다."
+            );
+        }
+
+        if (!Boolean.TRUE.equals(kakaoAccount.isEmailValid()) || !Boolean.TRUE.equals(kakaoAccount.isEmailVerified())) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_PARAMETER,
+                    "이메일 인증이 완료된 카카오 계정만 사용할 수 있습니다."
+            );
+        }
+
+        User user = resolveOrCreateSocialUser(
+                SocialType.KAKAO,
+                socialId,
+                email,
+                extractKakaoDisplayName(kakaoUserInfo, email)
+        );
+
+        LoginResponse loginResponse = authService.issueTokens(user);
+        return SocialLoginResponse.from(loginResponse, user);
+    }
+
+    User resolveOrCreateSocialUser(
+            SocialType socialType,
+            String socialId,
+            String email,
+            String name
+    ) {
+        return userRepository.findBySocialTypeAndSocialIdAndDeletedAtIsNull(socialType, socialId)
+                .orElseGet(() -> userRepository.findByEmailAndDeletedAtIsNull(email)
+                        .map(existingUser -> validateExistingSocialUser(existingUser, socialType))
+                        .orElseGet(() -> userRepository.save(
+                                User.createSocialUser(
+                                        name,
+                                        email,
+                                        createDummyPassword(),
+                                        socialType,
+                                        socialId
+                                )
+                        )));
+    }
+
+    private User validateExistingSocialUser(User existingUser, SocialType socialType) {
+        if (existingUser.getSocialType() == socialType) {
+            return existingUser;
+        }
+
+        if (existingUser.getSocialType() == SocialType.LOCAL) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_PARAMETER,
+                    "이미 이메일/비밀번호로 가입된 계정입니다. 로컬 로그인을 이용해주세요."
+            );
+        }
+
+        throw new GeneralException(
+                GeneralErrorCode.INVALID_PARAMETER,
+                "이미 " + toKoreanProviderName(existingUser.getSocialType()) + " 계정으로 가입된 이메일입니다. 해당 소셜 로그인을 이용해주세요."
+        );
+    }
+
+    private GoogleUserInfo fetchGoogleUserInfo(String providerAccessToken) {
+        try {
+            GoogleUserInfo response = googleWebClient.get()
+                    .uri("/v1/userinfo")
+                    .headers(headers -> headers.setBearerAuth(providerAccessToken))
+                    .retrieve()
+                    .bodyToMono(GoogleUserInfo.class)
+                    .block(SOCIAL_API_TIMEOUT);
+
+            if (response == null) {
+                throw new GeneralException(
+                        GeneralErrorCode.INVALID_TOKEN,
+                        "구글 사용자 정보를 불러오지 못했습니다."
+                );
+            }
+
+            return response;
+        } catch (WebClientResponseException exception) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_TOKEN,
+                    "구글 액세스 토큰이 유효하지 않습니다."
+            );
+        } catch (WebClientRequestException exception) {
+            throw new GeneralException(
+                    GeneralErrorCode.EXTERNAL_SERVICE_TIMEOUT,
+                    "구글 사용자 정보 요청에 실패했습니다."
+            );
+        } catch (IllegalStateException exception) {
+            if (exception.getCause() instanceof TimeoutException) {
+                throw new GeneralException(
+                        GeneralErrorCode.EXTERNAL_SERVICE_TIMEOUT,
+                        "구글 사용자 정보 요청 시간이 초과되었습니다."
+                );
+            }
+            throw exception;
+        }
+    }
+
+    private KakaoUserInfo fetchKakaoUserInfo(String providerAccessToken) {
+        try {
+            KakaoUserInfo response = kakaoWebClient.get()
+                    .uri("/v2/user/me")
+                    .headers(headers -> headers.setBearerAuth(providerAccessToken))
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfo.class)
+                    .block(SOCIAL_API_TIMEOUT);
+
+            if (response == null) {
+                throw new GeneralException(
+                        GeneralErrorCode.INVALID_TOKEN,
+                        "카카오 사용자 정보를 불러오지 못했습니다."
+                );
+            }
+
+            return response;
+        } catch (WebClientResponseException exception) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_TOKEN,
+                    "카카오 액세스 토큰이 유효하지 않습니다."
+            );
+        } catch (WebClientRequestException exception) {
+            throw new GeneralException(
+                    GeneralErrorCode.EXTERNAL_SERVICE_TIMEOUT,
+                    "카카오 사용자 정보 요청에 실패했습니다."
+            );
+        } catch (IllegalStateException exception) {
+            if (exception.getCause() instanceof TimeoutException) {
+                throw new GeneralException(
+                        GeneralErrorCode.EXTERNAL_SERVICE_TIMEOUT,
+                        "카카오 사용자 정보 요청 시간이 초과되었습니다."
+                );
+            }
+            throw exception;
+        }
+    }
+
+    private String extractKakaoDisplayName(KakaoUserInfo kakaoUserInfo, String fallbackEmail) {
+        KakaoAccount kakaoAccount = kakaoUserInfo.kakaoAccount();
+        if (kakaoAccount != null && kakaoAccount.profile() != null && hasText(kakaoAccount.profile().nickname())) {
+            return kakaoAccount.profile().nickname();
+        }
+
+        if (kakaoUserInfo.properties() != null && hasText(kakaoUserInfo.properties().nickname())) {
+            return kakaoUserInfo.properties().nickname();
+        }
+
+        return fallbackEmail;
+    }
+
+    private String defaultDisplayName(String candidate, String fallbackEmail) {
+        return hasText(candidate) ? candidate : fallbackEmail;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String createDummyPassword() {
+        return passwordEncoder.encode(UUID.randomUUID().toString());
+    }
+
+    private String toKoreanProviderName(SocialType socialType) {
+        return switch (socialType) {
+            case GOOGLE -> "구글";
+            case KAKAO -> "카카오";
+            case LOCAL -> "로컬";
+        };
+    }
+
+    private record GoogleUserInfo(
+            String sub,
+            String email,
+            String name,
+            @JsonProperty("email_verified")
+            Boolean emailVerified
+    ) {
+    }
+
+    private record KakaoUserInfo(
+            Long id,
+            @JsonProperty("kakao_account")
+            KakaoAccount kakaoAccount,
+            KakaoProperties properties
+    ) {
+    }
+
+    private record KakaoAccount(
+            String email,
+            @JsonProperty("is_email_valid")
+            Boolean isEmailValid,
+            @JsonProperty("is_email_verified")
+            Boolean isEmailVerified,
+            KakaoProfile profile
+    ) {
+    }
+
+    private record KakaoProfile(
+            String nickname
+    ) {
+    }
+
+    private record KakaoProperties(
+            String nickname
+    ) {
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/auth/service/SocialAuthService.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/service/SocialAuthService.java
@@ -4,16 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.roddy.domain.auth.dto.response.LoginResponse;
 import com.roddy.domain.auth.dto.response.SocialLoginResponse;
 import com.roddy.domain.auth.entity.User;
-import com.roddy.domain.auth.repository.UserRepository;
 import com.roddy.domain.enums.SocialType;
 import com.roddy.global.apiPayload.code.GeneralErrorCode;
 import com.roddy.global.apiPayload.exception.GeneralException;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -23,30 +20,36 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 @Service
-@RequiredArgsConstructor
 public class SocialAuthService {
 
     private static final Duration SOCIAL_API_TIMEOUT = Duration.ofSeconds(5);
-    private static final String GOOGLE_BASE_URL = "https://openidconnect.googleapis.com";
-    private static final String KAKAO_BASE_URL = "https://kapi.kakao.com";
 
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
     private final AuthService authService;
+    private final SocialUserAccountService socialUserAccountService;
+    private final WebClient googleWebClient;
+    private final WebClient kakaoWebClient;
 
-    private final WebClient googleWebClient = WebClient.builder()
-            .baseUrl(GOOGLE_BASE_URL)
-            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-            .defaultHeader(HttpHeaders.USER_AGENT, "roddy-backend")
-            .build();
+    public SocialAuthService(
+            AuthService authService,
+            SocialUserAccountService socialUserAccountService,
+            WebClient.Builder webClientBuilder,
+            @Value("${app.oauth2.google-base-url:https://openidconnect.googleapis.com}") String googleBaseUrl,
+            @Value("${app.oauth2.kakao-base-url:https://kapi.kakao.com}") String kakaoBaseUrl
+    ) {
+        this.authService = authService;
+        this.socialUserAccountService = socialUserAccountService;
+        this.googleWebClient = webClientBuilder.clone()
+                .baseUrl(googleBaseUrl)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.USER_AGENT, "roddy-backend")
+                .build();
+        this.kakaoWebClient = webClientBuilder.clone()
+                .baseUrl(kakaoBaseUrl)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.USER_AGENT, "roddy-backend")
+                .build();
+    }
 
-    private final WebClient kakaoWebClient = WebClient.builder()
-            .baseUrl(KAKAO_BASE_URL)
-            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-            .defaultHeader(HttpHeaders.USER_AGENT, "roddy-backend")
-            .build();
-
-    @Transactional
     public SocialLoginResponse loginWithGoogle(String providerAccessToken) {
         GoogleUserInfo googleUserInfo = fetchGoogleUserInfo(providerAccessToken);
 
@@ -64,7 +67,7 @@ public class SocialAuthService {
             );
         }
 
-        User user = resolveOrCreateSocialUser(
+        User user = socialUserAccountService.resolveOrCreateSocialUser(
                 SocialType.GOOGLE,
                 googleUserInfo.sub(),
                 googleUserInfo.email(),
@@ -75,7 +78,6 @@ public class SocialAuthService {
         return SocialLoginResponse.from(loginResponse, user);
     }
 
-    @Transactional
     public SocialLoginResponse loginWithKakao(String providerAccessToken) {
         KakaoUserInfo kakaoUserInfo = fetchKakaoUserInfo(providerAccessToken);
         KakaoAccount kakaoAccount = kakaoUserInfo.kakaoAccount();
@@ -97,7 +99,7 @@ public class SocialAuthService {
             );
         }
 
-        User user = resolveOrCreateSocialUser(
+        User user = socialUserAccountService.resolveOrCreateSocialUser(
                 SocialType.KAKAO,
                 socialId,
                 email,
@@ -106,44 +108,6 @@ public class SocialAuthService {
 
         LoginResponse loginResponse = authService.issueTokens(user);
         return SocialLoginResponse.from(loginResponse, user);
-    }
-
-    User resolveOrCreateSocialUser(
-            SocialType socialType,
-            String socialId,
-            String email,
-            String name
-    ) {
-        return userRepository.findBySocialTypeAndSocialIdAndDeletedAtIsNull(socialType, socialId)
-                .orElseGet(() -> userRepository.findByEmailAndDeletedAtIsNull(email)
-                        .map(existingUser -> validateExistingSocialUser(existingUser, socialType))
-                        .orElseGet(() -> userRepository.save(
-                                User.createSocialUser(
-                                        name,
-                                        email,
-                                        createDummyPassword(),
-                                        socialType,
-                                        socialId
-                                )
-                        )));
-    }
-
-    private User validateExistingSocialUser(User existingUser, SocialType socialType) {
-        if (existingUser.getSocialType() == socialType) {
-            return existingUser;
-        }
-
-        if (existingUser.getSocialType() == SocialType.LOCAL) {
-            throw new GeneralException(
-                    GeneralErrorCode.INVALID_PARAMETER,
-                    "이미 이메일/비밀번호로 가입된 계정입니다. 로컬 로그인을 이용해주세요."
-            );
-        }
-
-        throw new GeneralException(
-                GeneralErrorCode.INVALID_PARAMETER,
-                "이미 " + toKoreanProviderName(existingUser.getSocialType()) + " 계정으로 가입된 이메일입니다. 해당 소셜 로그인을 이용해주세요."
-        );
     }
 
     private GoogleUserInfo fetchGoogleUserInfo(String providerAccessToken) {
@@ -232,27 +196,27 @@ public class SocialAuthService {
             return kakaoUserInfo.properties().nickname();
         }
 
-        return fallbackEmail;
+        return deriveFallbackNickname(fallbackEmail);
     }
 
     private String defaultDisplayName(String candidate, String fallbackEmail) {
-        return hasText(candidate) ? candidate : fallbackEmail;
+        return hasText(candidate) ? candidate : deriveFallbackNickname(fallbackEmail);
     }
 
     private boolean hasText(String value) {
         return value != null && !value.isBlank();
     }
 
-    private String createDummyPassword() {
-        return passwordEncoder.encode(UUID.randomUUID().toString());
-    }
+    private String deriveFallbackNickname(String email) {
+        if (hasText(email)) {
+            int separatorIndex = email.indexOf('@');
+            String localPart = separatorIndex > 0 ? email.substring(0, separatorIndex) : email;
+            if (hasText(localPart)) {
+                return localPart;
+            }
+        }
 
-    private String toKoreanProviderName(SocialType socialType) {
-        return switch (socialType) {
-            case GOOGLE -> "구글";
-            case KAKAO -> "카카오";
-            case LOCAL -> "로컬";
-        };
+        return "user-" + UUID.randomUUID().toString().substring(0, 8);
     }
 
     private record GoogleUserInfo(

--- a/roddy/src/main/java/com/roddy/domain/auth/service/SocialUserAccountService.java
+++ b/roddy/src/main/java/com/roddy/domain/auth/service/SocialUserAccountService.java
@@ -1,0 +1,133 @@
+package com.roddy.domain.auth.service;
+
+import com.roddy.domain.auth.entity.User;
+import com.roddy.domain.auth.repository.UserRepository;
+import com.roddy.domain.enums.SocialType;
+import com.roddy.global.apiPayload.code.GeneralErrorCode;
+import com.roddy.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SocialUserAccountService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public User resolveOrCreateSocialUser(
+            SocialType socialType,
+            String socialId,
+            String email,
+            String name
+    ) {
+        return userRepository.findBySocialTypeAndSocialIdAndDeletedAtIsNull(socialType, socialId)
+                .orElseGet(() -> userRepository.findByEmailAndDeletedAtIsNull(email)
+                        .map(existingUser -> validateExistingSocialUser(existingUser, socialType, socialId))
+                        .orElseGet(() -> createSocialUser(socialType, socialId, email, name)));
+    }
+
+    private User validateExistingSocialUser(User existingUser, SocialType socialType, String socialId) {
+        if (existingUser.getSocialType() != socialType) {
+            if (existingUser.getSocialType() == SocialType.LOCAL) {
+                throw new GeneralException(
+                        GeneralErrorCode.INVALID_PARAMETER,
+                        "이미 이메일/비밀번호로 가입된 계정입니다. 로컬 로그인을 이용해주세요."
+                );
+            }
+
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_PARAMETER,
+                    "이미 " + toKoreanProviderName(existingUser.getSocialType()) + " 계정으로 가입된 이메일입니다. 해당 소셜 로그인을 이용해주세요."
+            );
+        }
+
+        if (!hasText(existingUser.getSocialId())) {
+            existingUser.linkSocialId(socialId);
+            try {
+                return userRepository.saveAndFlush(existingUser);
+            } catch (DataIntegrityViolationException exception) {
+                return recoverExistingSocialUser(socialType, socialId, existingUser.getEmail());
+            }
+        }
+
+        if (!existingUser.getSocialId().equals(socialId)) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_PARAMETER,
+                    "이미 다른 " + toKoreanProviderName(socialType) + " 계정으로 가입된 이메일입니다. 해당 소셜 로그인을 이용해주세요."
+            );
+        }
+
+        return existingUser;
+    }
+
+    private User createSocialUser(SocialType socialType, String socialId, String email, String name) {
+        try {
+            return userRepository.saveAndFlush(
+                    User.createSocialUser(
+                            name,
+                            email,
+                            createDummyPassword(),
+                            socialType,
+                            socialId
+                    )
+            );
+        } catch (DataIntegrityViolationException exception) {
+            return recoverExistingSocialUser(socialType, socialId, email);
+        }
+    }
+
+    private User recoverExistingSocialUser(SocialType socialType, String socialId, String email) {
+        return userRepository.findBySocialTypeAndSocialIdAndDeletedAtIsNull(socialType, socialId)
+                .orElseGet(() -> userRepository.findByEmailAndDeletedAtIsNull(email)
+                        .map(existingUser -> validateRecoveredUser(existingUser, socialType, socialId))
+                        .orElseThrow(() -> new GeneralException(GeneralErrorCode.INTERNAL_SERVER_ERROR)));
+    }
+
+    private User validateRecoveredUser(User existingUser, SocialType socialType, String socialId) {
+        if (existingUser.getSocialType() != socialType) {
+            if (existingUser.getSocialType() == SocialType.LOCAL) {
+                throw new GeneralException(
+                        GeneralErrorCode.INVALID_PARAMETER,
+                        "이미 이메일/비밀번호로 가입된 계정입니다. 로컬 로그인을 이용해주세요."
+                );
+            }
+
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_PARAMETER,
+                    "이미 " + toKoreanProviderName(existingUser.getSocialType()) + " 계정으로 가입된 이메일입니다. 해당 소셜 로그인을 이용해주세요."
+            );
+        }
+
+        if (!hasText(existingUser.getSocialId()) || !existingUser.getSocialId().equals(socialId)) {
+            throw new GeneralException(
+                    GeneralErrorCode.INVALID_PARAMETER,
+                    "이미 다른 " + toKoreanProviderName(socialType) + " 계정으로 가입된 이메일입니다. 해당 소셜 로그인을 이용해주세요."
+            );
+        }
+
+        return existingUser;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String createDummyPassword() {
+        return passwordEncoder.encode(UUID.randomUUID().toString());
+    }
+
+    private String toKoreanProviderName(SocialType socialType) {
+        return switch (socialType) {
+            case GOOGLE -> "구글";
+            case KAKAO -> "카카오";
+            case LOCAL -> "로컬";
+        };
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/enums/SocialType.java
+++ b/roddy/src/main/java/com/roddy/domain/enums/SocialType.java
@@ -2,5 +2,6 @@ package com.roddy.domain.enums;
 
 public enum SocialType {
     LOCAL,
-    GOOGLE
+    GOOGLE,
+    KAKAO
 }

--- a/roddy/src/main/resources/application-dev.yaml
+++ b/roddy/src/main/resources/application-dev.yaml
@@ -47,6 +47,8 @@ jwt:
 app:
   oauth2:
     redirect-uri: ${APP_OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/redirect}
+    google-base-url: ${APP_OAUTH2_GOOGLE_BASE_URL:https://openidconnect.googleapis.com}
+    kakao-base-url: ${APP_OAUTH2_KAKAO_BASE_URL:https://kapi.kakao.com}
   github:
     client-id: ${GITHUB_CLIENT_ID:}
     client-secret: ${GITHUB_CLIENT_SECRET:}

--- a/roddy/src/main/resources/application-prod.yaml
+++ b/roddy/src/main/resources/application-prod.yaml
@@ -43,6 +43,8 @@ jwt:
 app:
   oauth2:
     redirect-uri: ${APP_OAUTH2_REDIRECT_URI}
+    google-base-url: ${APP_OAUTH2_GOOGLE_BASE_URL:https://openidconnect.googleapis.com}
+    kakao-base-url: ${APP_OAUTH2_KAKAO_BASE_URL:https://kapi.kakao.com}
   github:
     client-id: ${GITHUB_CLIENT_ID}
     client-secret: ${GITHUB_CLIENT_SECRET}


### PR DESCRIPTION
## What Changed
- `POST /api/auth/google`, `POST /api/auth/kakao` 소셜 로그인 REST API를 추가했습니다.
- 프론트에서 전달한 provider access token으로 Google/Kakao 사용자 정보를 조회하고 Roddy JWT를 발급하도록 구현했습니다.
- 응답에 `accessToken`, `refreshToken`, `isOnboard`, `githubConnected`, `user(id, email, nickname)`를 포함하도록 맞췄습니다.
- `KAKAO` 소셜 타입, `socialType + socialId` 기반 사용자 조회, provider별 사용자 식별자 fallback을 함께 보강했습니다.

## Why
- 프론트는 카카오/구글 소셜 로그인 엔드포인트와 `user` 포함 응답을 기대하고 있었지만, 백엔드는 기존에 `signup/login/reissue/logout`만 공개하고 있었습니다.
- 그 결과 프론트 인증 플로우와 백엔드 인증 API 계약이 맞지 않아 실제 소셜 로그인을 연결할 수 없는 상태였습니다.

## Impact
- 프론트는 소셜 로그인 후 provider access token만 백엔드에 전달하면 Roddy 세션 토큰과 사용자 정보를 바로 받을 수 있습니다.
- 동일 이메일이 이미 로컬 계정이거나 다른 소셜 계정으로 가입된 경우를 예외 처리해 로그인 충돌을 방지했습니다.
- 카카오 로그인은 이메일 동의 및 검증된 이메일이 있는 계정만 허용합니다.

## Validation
- `bash ./gradlew compileJava`

## Notes
- 백엔드 API는 준비되었지만, 프론트 `SocialLoginButtons`는 현재 mock 동작이라 실제 카카오/구글 SDK로 access token을 받아 새 엔드포인트를 호출하는 연결은 별도 작업이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added social login with Google and Kakao.
  - Users can sign in using provider access tokens and receive application access and refresh tokens.
  - Added support for creating and recognizing social accounts.
  - Login responses now include onboarding status, GitHub connection status, and basic user information.

- **Bug Fixes**
  - Improved OAuth account identification across supported providers.
  - Added validation and clearer handling for invalid, unavailable, or unverified social-login accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->