### PR TITLE
[Feat] 스터디 모집자 관리 API 추가 (#18)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "ko-KR"
+tone_instructions: "모든 리뷰와 요약은 자연스러운 한국어로 작성하고, 근거 기반으로 핵심 위험과 개선 방향을 명확히 설명하세요."
+early_access: false
+
+reviews:
+  profile: "assertive"
+  high_level_summary: true
+  review_status: true
+  poem: false
+  request_changes_workflow: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_instructions:
+    - path: "src/main/java/**/*.java"
+      instructions: |
+        다음 관점을 우선순위 높게 검토하세요.
+        - 비동기 처리 안정성: blocking I/O, 이벤트 루프/스레드 점유, thread starvation, backpressure, queue 적체, retry/idempotency, timeout, transaction 경계, 부분 실패 복구 가능성
+        - 외부 API 호출 성능: connection pooling, 불필요한 직렬화/역직렬화, 동기 호출 병목, 재시도 정책, rate limit 대응, 대량 요청 시 처리량 저하 가능성
+        - 데이터 접근 성능: N+1, 과도한 조회/저장, 락 경합, 긴 트랜잭션, 불필요한 flush/serialize 비용
+        - 코드 완성도: 객체 지향 설계의 응집도/책임 분리/SRP, 중복 제거, 명확한 이름, 테스트 용이성, 예외 처리 일관성, 클린코드 관점의 가독성과 유지보수성
+        리뷰 시 단순 스타일 지적보다 실제 장애 가능성, 성능 병목, 설계상 리스크를 우선 보고하세요.
+    - path: "src/test/**/*.java"
+      instructions: |
+        테스트가 동시성, 재시도, timeout, 실패 복구, 멱등성 같은 비동기 시나리오를 충분히 검증하는지 중점적으로 확인하세요.
+        해피패스만 있는 경우 경계 조건과 회귀 위험을 지적하세요.
+    - path: "ops/db/migrations/**/*.sql"
+      instructions: |
+        스키마 변경이 현재 운영 DB 엔진과 맞는지, 대용량 payload 저장/인덱스/락/호환성 측면에서 성능 및 운영 리스크가 없는지 검토하세요.
+
+chat:
+  auto_reply: true

--- a/roddy/src/main/java/com/roddy/domain/study/controller/StudyController.java
+++ b/roddy/src/main/java/com/roddy/domain/study/controller/StudyController.java
@@ -2,6 +2,7 @@ package com.roddy.domain.study.controller;
 
 import com.roddy.domain.study.dto.request.StudyPostCreateRequest;
 import com.roddy.domain.study.dto.request.StudySearchCondition;
+import com.roddy.domain.study.dto.request.StudyApplicationStatusUpdateRequest;
 import com.roddy.domain.study.dto.response.MyStudyApplicationListResponse;
 import com.roddy.domain.study.dto.response.StudyApplicationResponse;
 import com.roddy.domain.study.dto.response.StudyCloseResponse;
@@ -89,6 +90,20 @@ public class StudyController {
         return ApiResponse.onSuccess(
                 "스터디 지원이 완료되었습니다.",
                 studyService.applyToStudy(studyId, requireUser(userDetails))
+        );
+    }
+
+    @PatchMapping("/{studyId}/applications/{applicationId}")
+    @Operation(summary = "스터디 지원 상태 변경")
+    public ApiResponse<StudyApplicationResponse> updateApplicationStatus(
+            @PathVariable Long studyId,
+            @PathVariable Long applicationId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody StudyApplicationStatusUpdateRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                "스터디 지원 상태를 변경했습니다.",
+                studyService.updateApplicationStatus(studyId, applicationId, requireUser(userDetails), request.status())
         );
     }
 

--- a/roddy/src/main/java/com/roddy/domain/study/controller/StudyController.java
+++ b/roddy/src/main/java/com/roddy/domain/study/controller/StudyController.java
@@ -131,6 +131,18 @@ public class StudyController {
         );
     }
 
+    @PatchMapping("/{studyId}/reopen")
+    @Operation(summary = "스터디 모집 재오픈 처리")
+    public ApiResponse<StudyCloseResponse> reopenStudy(
+            @PathVariable Long studyId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return ApiResponse.onSuccess(
+                "스터디 모집 상태를 변경했습니다.",
+                studyService.reopenStudyPost(studyId, requireUser(userDetails))
+        );
+    }
+
     @GetMapping("/applications/me")
     @Operation(summary = "내가 지원한 스터디 목록 조회")
     public ApiResponse<MyStudyApplicationListResponse> getMyApplications(

--- a/roddy/src/main/java/com/roddy/domain/study/dto/request/StudyApplicationStatusUpdateRequest.java
+++ b/roddy/src/main/java/com/roddy/domain/study/dto/request/StudyApplicationStatusUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.roddy.domain.study.dto.request;
+
+import com.roddy.domain.study.enums.StudyApplicationStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record StudyApplicationStatusUpdateRequest(
+        @NotNull
+        StudyApplicationStatus status
+) {
+}

--- a/roddy/src/main/java/com/roddy/domain/study/dto/response/StudyApplicantSummaryResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/study/dto/response/StudyApplicantSummaryResponse.java
@@ -1,0 +1,13 @@
+package com.roddy.domain.study.dto.response;
+
+import java.time.LocalDateTime;
+
+public record StudyApplicantSummaryResponse(
+        Long applicationId,
+        Long applicantId,
+        String applicantName,
+        String status,
+        String statusDisplayName,
+        LocalDateTime appliedAt
+) {
+}

--- a/roddy/src/main/java/com/roddy/domain/study/dto/response/StudyPostDetailResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/study/dto/response/StudyPostDetailResponse.java
@@ -1,6 +1,7 @@
 package com.roddy.domain.study.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record StudyPostDetailResponse(
         Long id,
@@ -18,6 +19,7 @@ public record StudyPostDetailResponse(
         String statusDisplayName,
         String myApplicationStatus,
         String myApplicationStatusDisplayName,
-        boolean isAuthor
+        boolean isAuthor,
+        List<StudyApplicantSummaryResponse> applicants
 ) {
 }

--- a/roddy/src/main/java/com/roddy/domain/study/entity/StudyApplication.java
+++ b/roddy/src/main/java/com/roddy/domain/study/entity/StudyApplication.java
@@ -70,8 +70,24 @@ public class StudyApplication extends BaseEntity {
         this.status = StudyApplicationStatus.CANCELED;
     }
 
+    public void accept() {
+        this.status = StudyApplicationStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        this.status = StudyApplicationStatus.REJECTED;
+    }
+
     public boolean isApplied() {
         return this.status == StudyApplicationStatus.APPLIED;
+    }
+
+    public boolean isAccepted() {
+        return this.status == StudyApplicationStatus.ACCEPTED;
+    }
+
+    public boolean isRejected() {
+        return this.status == StudyApplicationStatus.REJECTED;
     }
 
     public boolean isCanceled() {

--- a/roddy/src/main/java/com/roddy/domain/study/entity/StudyPost.java
+++ b/roddy/src/main/java/com/roddy/domain/study/entity/StudyPost.java
@@ -110,6 +110,10 @@ public class StudyPost extends BaseEntity {
         this.status = StudyRecruitStatus.CLOSED;
     }
 
+    public void reopen() {
+        this.status = StudyRecruitStatus.RECRUITING;
+    }
+
     public boolean isClosed() {
         return this.status == StudyRecruitStatus.CLOSED;
     }

--- a/roddy/src/main/java/com/roddy/domain/study/enums/StudyApplicationStatus.java
+++ b/roddy/src/main/java/com/roddy/domain/study/enums/StudyApplicationStatus.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum StudyApplicationStatus {
     APPLIED("지원 완료"),
+    ACCEPTED("수락"),
+    REJECTED("거절"),
     CANCELED("취소");
 
     private final String displayName;

--- a/roddy/src/main/java/com/roddy/domain/study/repository/StudyApplicationRepository.java
+++ b/roddy/src/main/java/com/roddy/domain/study/repository/StudyApplicationRepository.java
@@ -9,10 +9,20 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface StudyApplicationRepository extends JpaRepository<StudyApplication, Long> {
 
     Optional<StudyApplication> findByStudyPost_IdAndApplicant_Id(Long studyId, Long applicantId);
+
+    @Query("""
+            select sa
+            from StudyApplication sa
+            join fetch sa.applicant
+            where sa.studyPost.id = :studyId
+            order by sa.createdAt asc
+            """)
+    List<StudyApplication> findAllByStudyPostIdOrderByCreatedAtAsc(@Param("studyId") Long studyId);
 
     @Query("""
             select sa

--- a/roddy/src/main/java/com/roddy/domain/study/repository/StudyApplicationRepository.java
+++ b/roddy/src/main/java/com/roddy/domain/study/repository/StudyApplicationRepository.java
@@ -15,6 +15,10 @@ public interface StudyApplicationRepository extends JpaRepository<StudyApplicati
 
     Optional<StudyApplication> findByStudyPost_IdAndApplicant_Id(Long studyId, Long applicantId);
 
+    Optional<StudyApplication> findByIdAndStudyPost_Id(Long applicationId, Long studyId);
+
+    long countByStudyPost_IdAndStatus(Long studyId, StudyApplicationStatus status);
+
     @Query("""
             select sa
             from StudyApplication sa

--- a/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
+++ b/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
@@ -6,6 +6,7 @@ import com.roddy.domain.study.dto.request.StudyPostCreateRequest;
 import com.roddy.domain.study.dto.request.StudySearchCondition;
 import com.roddy.domain.study.dto.response.MyStudyApplicationListResponse;
 import com.roddy.domain.study.dto.response.MyStudyApplicationResponse;
+import com.roddy.domain.study.dto.response.StudyApplicantSummaryResponse;
 import com.roddy.domain.study.dto.response.StudyApplicationResponse;
 import com.roddy.domain.study.dto.response.StudyCloseResponse;
 import com.roddy.domain.study.dto.response.StudyPostCreateResponse;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -100,7 +102,8 @@ public class StudyService {
                 studyPost.getStatus().getDisplayName(),
                 myStatus == null ? null : myStatus.name(),
                 myStatus == null ? null : myStatus.getDisplayName(),
-                currentUserId != null && studyPost.isAuthor(currentUserId)
+                currentUserId != null && studyPost.isAuthor(currentUserId),
+                List.of()
         );
     }
 

--- a/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
+++ b/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
@@ -78,6 +78,7 @@ public class StudyService {
     public StudyPostDetailResponse getStudyPostDetail(Long studyId, Long currentUserId) {
         StudyPost studyPost = studyPostRepository.findDetailById(studyId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.STUDY_NOT_FOUND));
+        boolean isAuthor = currentUserId != null && studyPost.isAuthor(currentUserId);
 
         StudyApplicationStatus myStatus = null;
         if (currentUserId != null) {
@@ -85,6 +86,12 @@ public class StudyService {
                     .map(StudyApplication::getStatus)
                     .orElse(null);
         }
+
+        List<StudyApplicantSummaryResponse> applicants = isAuthor
+                ? studyApplicationRepository.findAllByStudyPostIdOrderByCreatedAtAsc(studyId).stream()
+                .map(this::toStudyApplicantSummary)
+                .toList()
+                : List.of();
 
         return new StudyPostDetailResponse(
                 studyPost.getId(),
@@ -102,8 +109,8 @@ public class StudyService {
                 studyPost.getStatus().getDisplayName(),
                 myStatus == null ? null : myStatus.name(),
                 myStatus == null ? null : myStatus.getDisplayName(),
-                currentUserId != null && studyPost.isAuthor(currentUserId),
-                List.of()
+                isAuthor,
+                applicants
         );
     }
 
@@ -228,6 +235,17 @@ public class StudyService {
                 post.getApplicantCount(),
                 post.getStatus().name(),
                 post.getStatus().getDisplayName(),
+                application.getStatus().name(),
+                application.getStatus().getDisplayName(),
+                application.getCreatedAt()
+        );
+    }
+
+    private StudyApplicantSummaryResponse toStudyApplicantSummary(StudyApplication application) {
+        return new StudyApplicantSummaryResponse(
+                application.getId(),
+                application.getApplicant().getId(),
+                application.getApplicant().getNickname(),
                 application.getStatus().name(),
                 application.getStatus().getDisplayName(),
                 application.getCreatedAt()

--- a/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
+++ b/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
@@ -223,6 +223,30 @@ public class StudyService {
         );
     }
 
+    @Transactional
+    public StudyCloseResponse reopenStudyPost(Long studyId, Long userId) {
+        StudyPost studyPost = getStudyPostForUpdate(studyId);
+
+        if (!studyPost.isAuthor(userId)) {
+            throw new GeneralException(GeneralErrorCode.STUDY_FORBIDDEN);
+        }
+
+        long acceptedCount = studyApplicationRepository.countByStudyPost_IdAndStatus(studyId, StudyApplicationStatus.ACCEPTED);
+        if (acceptedCount >= studyPost.getCapacity()) {
+            throw new GeneralException(GeneralErrorCode.STUDY_REOPEN_NOT_AVAILABLE);
+        }
+
+        if (studyPost.isClosed()) {
+            studyPost.reopen();
+        }
+
+        return new StudyCloseResponse(
+                studyPost.getId(),
+                studyPost.getStatus().name(),
+                studyPost.getStatus().getDisplayName()
+        );
+    }
+
     @Transactional(readOnly = true)
     public MyStudyApplicationListResponse getMyApplications(Long userId, StudyApplicationStatus status, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));

--- a/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
+++ b/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
@@ -145,6 +145,46 @@ public class StudyService {
     }
 
     @Transactional
+    public StudyApplicationResponse updateApplicationStatus(Long studyId, Long applicationId, Long userId, StudyApplicationStatus targetStatus) {
+        StudyPost studyPost = getStudyPostForUpdate(studyId);
+
+        if (!studyPost.isAuthor(userId)) {
+            throw new GeneralException(GeneralErrorCode.STUDY_FORBIDDEN);
+        }
+        if (targetStatus != StudyApplicationStatus.ACCEPTED && targetStatus != StudyApplicationStatus.REJECTED) {
+            throw new GeneralException(GeneralErrorCode.INVALID_STUDY_APPLICATION_STATUS);
+        }
+
+        StudyApplication studyApplication = studyApplicationRepository.findByIdAndStudyPost_Id(applicationId, studyId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.STUDY_APPLICATION_NOT_FOUND));
+
+        if (!studyApplication.isApplied()) {
+            throw new GeneralException(GeneralErrorCode.STUDY_APPLICATION_STATUS_ALREADY_PROCESSED);
+        }
+
+        if (targetStatus == StudyApplicationStatus.ACCEPTED) {
+            long acceptedCount = studyApplicationRepository.countByStudyPost_IdAndStatus(studyId, StudyApplicationStatus.ACCEPTED);
+            if (acceptedCount >= studyPost.getCapacity()) {
+                throw new GeneralException(GeneralErrorCode.STUDY_CAPACITY_FULL);
+            }
+            studyApplication.accept();
+            if (acceptedCount + 1 >= studyPost.getCapacity()) {
+                studyPost.close();
+            }
+        } else {
+            studyApplication.reject();
+            studyPost.decreaseApplicantCount();
+        }
+
+        return new StudyApplicationResponse(
+                studyApplication.getId(),
+                studyApplication.getStatus().name(),
+                studyApplication.getStatus().getDisplayName(),
+                studyPost.getApplicantCount()
+        );
+    }
+
+    @Transactional
     public StudyApplicationResponse cancelMyApplication(Long studyId, Long userId) {
         StudyPost studyPost = getStudyPostForUpdate(studyId);
         StudyApplication studyApplication = studyApplicationRepository.findByStudyPost_IdAndApplicant_Id(studyId, userId)
@@ -198,7 +238,7 @@ public class StudyService {
     }
 
     private StudyApplication reapply(StudyApplication existing, StudyPost studyPost) {
-        if (existing.isApplied()) {
+        if (!existing.isCanceled()) {
             throw new GeneralException(GeneralErrorCode.STUDY_ALREADY_APPLIED);
         }
         existing.apply();

--- a/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
+++ b/roddy/src/main/java/com/roddy/domain/study/service/StudyService.java
@@ -194,8 +194,11 @@ public class StudyService {
             throw new GeneralException(GeneralErrorCode.STUDY_APPLICATION_ALREADY_CANCELED);
         }
 
+        boolean shouldDecreaseApplicantCount = studyApplication.isApplied() || studyApplication.isAccepted();
         studyApplication.cancel();
-        studyPost.decreaseApplicantCount();
+        if (shouldDecreaseApplicantCount) {
+            studyPost.decreaseApplicantCount();
+        }
 
         return new StudyApplicationResponse(
                 studyApplication.getId(),

--- a/roddy/src/main/java/com/roddy/global/apiPayload/code/GeneralErrorCode.java
+++ b/roddy/src/main/java/com/roddy/global/apiPayload/code/GeneralErrorCode.java
@@ -45,6 +45,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
     STUDY_ALREADY_APPLIED(HttpStatus.CONFLICT, "STUDY_4093", "이미 지원한 스터디입니다."),
     STUDY_APPLICATION_ALREADY_CANCELED(HttpStatus.CONFLICT, "STUDY_4094", "이미 취소된 스터디 지원입니다."),
     STUDY_APPLICATION_STATUS_ALREADY_PROCESSED(HttpStatus.CONFLICT, "STUDY_4095", "이미 처리된 스터디 지원 상태입니다."),
+    STUDY_REOPEN_NOT_AVAILABLE(HttpStatus.CONFLICT, "STUDY_4096", "모집 인원이 모두 확정된 스터디는 다시 모집중으로 변경할 수 없습니다."),
     STUDY_AUTHOR_CANNOT_APPLY(HttpStatus.BAD_REQUEST, "STUDY_4001", "작성자는 자신의 스터디에 지원할 수 없습니다."),
     INVALID_STUDY_MODE_LOCATION(HttpStatus.BAD_REQUEST, "STUDY_4002", "대면 스터디는 장소가 필수입니다."),
     INVALID_STUDY_SCHEDULE(HttpStatus.BAD_REQUEST, "STUDY_4003", "스터디 진행 시간은 현재 시각 이후여야 합니다."),

--- a/roddy/src/main/java/com/roddy/global/apiPayload/code/GeneralErrorCode.java
+++ b/roddy/src/main/java/com/roddy/global/apiPayload/code/GeneralErrorCode.java
@@ -44,9 +44,11 @@ public enum GeneralErrorCode implements BaseErrorCode {
     STUDY_CAPACITY_FULL(HttpStatus.CONFLICT, "STUDY_4092", "스터디 모집 인원이 가득 찼습니다."),
     STUDY_ALREADY_APPLIED(HttpStatus.CONFLICT, "STUDY_4093", "이미 지원한 스터디입니다."),
     STUDY_APPLICATION_ALREADY_CANCELED(HttpStatus.CONFLICT, "STUDY_4094", "이미 취소된 스터디 지원입니다."),
+    STUDY_APPLICATION_STATUS_ALREADY_PROCESSED(HttpStatus.CONFLICT, "STUDY_4095", "이미 처리된 스터디 지원 상태입니다."),
     STUDY_AUTHOR_CANNOT_APPLY(HttpStatus.BAD_REQUEST, "STUDY_4001", "작성자는 자신의 스터디에 지원할 수 없습니다."),
     INVALID_STUDY_MODE_LOCATION(HttpStatus.BAD_REQUEST, "STUDY_4002", "대면 스터디는 장소가 필수입니다."),
-    INVALID_STUDY_SCHEDULE(HttpStatus.BAD_REQUEST, "STUDY_4003", "스터디 진행 시간은 현재 시각 이후여야 합니다.");
+    INVALID_STUDY_SCHEDULE(HttpStatus.BAD_REQUEST, "STUDY_4003", "스터디 진행 시간은 현재 시각 이후여야 합니다."),
+    INVALID_STUDY_APPLICATION_STATUS(HttpStatus.BAD_REQUEST, "STUDY_4004", "스터디 지원 상태는 ACCEPTED 또는 REJECTED만 설정할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/roddy/src/test/java/com/roddy/domain/study/controller/StudyControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/study/controller/StudyControllerTest.java
@@ -323,7 +323,7 @@ class StudyControllerTest {
     void 모집자가_지원자를_수락할_수_있다() throws Exception {
         User author = saveUser("approve-author@example.com", "작성자");
         User applicant = saveUser("approve-user@example.com", "지원자");
-        StudyPost studyPost = saveStudy(author, "승인 테스트", "내용", StudyMode.ONLINE, "Discord", LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.RECRUITING);
+        StudyPost studyPost = saveStudy(author, "승인 테스트", "내용", StudyMode.ONLINE, "Discord", LocalDateTime.now().plusDays(2), 1, 1, StudyRecruitStatus.RECRUITING);
         StudyApplication application = saveApplication(studyPost, applicant, StudyApplicationStatus.APPLIED);
 
         mockMvc.perform(patch("/api/studies/{studyId}/applications/{applicationId}", studyPost.getId(), application.getId())
@@ -334,6 +334,11 @@ class StudyControllerTest {
                 .andExpect(jsonPath("$.result.status").value("ACCEPTED"))
                 .andExpect(jsonPath("$.result.statusDisplayName").value("수락"))
                 .andExpect(jsonPath("$.result.applicantCount").value(1));
+
+        mockMvc.perform(get("/api/studies/{studyId}", studyPost.getId())
+                        .with(user(new UserDetailsImpl(author))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("CLOSED"));
     }
 
     @Test
@@ -382,6 +387,22 @@ class StudyControllerTest {
                         .content(objectMapper.writeValueAsString(new UpdateApplicationStatusRequest("REJECTED"))))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    void 거절된_지원_취소시_다른_활성_지원자_카운트는_유지된다() throws Exception {
+        User author = saveUser("cancel-rejected-author@example.com", "작성자");
+        User rejectedApplicant = saveUser("cancel-rejected-user@example.com", "거절지원자");
+        User activeApplicant = saveUser("cancel-active-user@example.com", "활성지원자");
+        StudyPost studyPost = saveStudy(author, "거절 취소 테스트", "내용", StudyMode.ONLINE, null, LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.RECRUITING);
+        saveApplication(studyPost, rejectedApplicant, StudyApplicationStatus.REJECTED);
+        saveApplication(studyPost, activeApplicant, StudyApplicationStatus.APPLIED);
+
+        mockMvc.perform(delete("/api/studies/{studyId}/applications/me", studyPost.getId())
+                        .with(user(new UserDetailsImpl(rejectedApplicant))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("CANCELED"))
+                .andExpect(jsonPath("$.result.applicantCount").value(1));
     }
 
     @Test

--- a/roddy/src/test/java/com/roddy/domain/study/controller/StudyControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/study/controller/StudyControllerTest.java
@@ -22,11 +22,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDateTime;
 
@@ -207,7 +210,8 @@ class StudyControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.id").value(studyPost.getId()))
                 .andExpect(jsonPath("$.result.authorName").value("상세작성자"))
-                .andExpect(jsonPath("$.result.myApplicationStatus").value(nullValue()));
+                .andExpect(jsonPath("$.result.myApplicationStatus").value(nullValue()))
+                .andExpect(jsonPath("$.result.applicants.length()").value(0));
     }
 
     @Test
@@ -222,6 +226,22 @@ class StudyControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.myApplicationStatus").value("APPLIED"))
                 .andExpect(jsonPath("$.result.myApplicationStatusDisplayName").value("지원 완료"));
+    }
+
+    @Test
+    void 작성자가_상세_조회시_지원자_목록_반환() throws Exception {
+        User author = saveUser("manager-author@example.com", "모집자");
+        User applicant = saveUser("manager-applicant@example.com", "지원자A");
+        StudyPost studyPost = saveStudy(author, "모집자 상세", "내용", StudyMode.ONLINE, "Discord", LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.RECRUITING);
+        saveApplication(studyPost, applicant, StudyApplicationStatus.APPLIED);
+
+        mockMvc.perform(get("/api/studies/{studyId}", studyPost.getId())
+                        .with(user(new UserDetailsImpl(author))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.isAuthor").value(true))
+                .andExpect(jsonPath("$.result.applicants.length()").value(1))
+                .andExpect(jsonPath("$.result.applicants[0].applicantName").value("지원자A"))
+                .andExpect(jsonPath("$.result.applicants[0].status").value("APPLIED"));
     }
 
     @Test
@@ -300,6 +320,71 @@ class StudyControllerTest {
     }
 
     @Test
+    void 모집자가_지원자를_수락할_수_있다() throws Exception {
+        User author = saveUser("approve-author@example.com", "작성자");
+        User applicant = saveUser("approve-user@example.com", "지원자");
+        StudyPost studyPost = saveStudy(author, "승인 테스트", "내용", StudyMode.ONLINE, "Discord", LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.RECRUITING);
+        StudyApplication application = saveApplication(studyPost, applicant, StudyApplicationStatus.APPLIED);
+
+        mockMvc.perform(patch("/api/studies/{studyId}/applications/{applicationId}", studyPost.getId(), application.getId())
+                        .with(user(new UserDetailsImpl(author)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateApplicationStatusRequest("ACCEPTED"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("ACCEPTED"))
+                .andExpect(jsonPath("$.result.statusDisplayName").value("수락"))
+                .andExpect(jsonPath("$.result.applicantCount").value(1));
+    }
+
+    @Test
+    void 모집자가_지원자를_거절하면_활성_지원자수가_감소한다() throws Exception {
+        User author = saveUser("reject-author@example.com", "작성자");
+        User applicant = saveUser("reject-user@example.com", "지원자");
+        StudyPost studyPost = saveStudy(author, "거절 테스트", "내용", StudyMode.ONLINE, "Discord", LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.RECRUITING);
+        StudyApplication application = saveApplication(studyPost, applicant, StudyApplicationStatus.APPLIED);
+
+        mockMvc.perform(patch("/api/studies/{studyId}/applications/{applicationId}", studyPost.getId(), application.getId())
+                        .with(user(new UserDetailsImpl(author)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateApplicationStatusRequest("REJECTED"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("REJECTED"))
+                .andExpect(jsonPath("$.result.statusDisplayName").value("거절"))
+                .andExpect(jsonPath("$.result.applicantCount").value(0));
+    }
+
+    @Test
+    void 작성자가_아닌_사용자는_지원_상태를_변경할_수_없다() throws Exception {
+        User author = saveUser("forbidden-author@example.com", "작성자");
+        User applicant = saveUser("forbidden-applicant@example.com", "지원자");
+        User otherUser = saveUser("forbidden-other@example.com", "다른유저");
+        StudyPost studyPost = saveStudy(author, "권한 테스트", "내용", StudyMode.ONLINE, "Discord", LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.RECRUITING);
+        StudyApplication application = saveApplication(studyPost, applicant, StudyApplicationStatus.APPLIED);
+
+        mockMvc.perform(patch("/api/studies/{studyId}/applications/{applicationId}", studyPost.getId(), application.getId())
+                        .with(user(new UserDetailsImpl(otherUser)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateApplicationStatusRequest("ACCEPTED"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    void 이미_처리된_지원은_다시_변경할_수_없다() throws Exception {
+        User author = saveUser("processed-author@example.com", "작성자");
+        User applicant = saveUser("processed-applicant@example.com", "지원자");
+        StudyPost studyPost = saveStudy(author, "처리 완료 테스트", "내용", StudyMode.ONLINE, "Discord", LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.RECRUITING);
+        StudyApplication application = saveApplication(studyPost, applicant, StudyApplicationStatus.ACCEPTED);
+
+        mockMvc.perform(patch("/api/studies/{studyId}/applications/{applicationId}", studyPost.getId(), application.getId())
+                        .with(user(new UserDetailsImpl(author)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateApplicationStatusRequest("REJECTED"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
     void 모집글_작성자가_모집_완료_처리_성공() throws Exception {
         User author = saveUser("close-author@example.com", "작성자");
         StudyPost studyPost = saveStudy(author, "마감 처리", "내용", StudyMode.ONLINE, null, LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.RECRUITING);
@@ -319,6 +404,31 @@ class StudyControllerTest {
         mockMvc.perform(patch("/api/studies/{studyId}/close", studyPost.getId())
                         .with(user(new UserDetailsImpl(otherUser))))
                 .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    void 모집글_작성자가_스터디를_재오픈할_수_있다() throws Exception {
+        User author = saveUser("reopen-author@example.com", "작성자");
+        StudyPost studyPost = saveStudy(author, "재오픈 테스트", "내용", StudyMode.ONLINE, null, LocalDateTime.now().plusDays(2), 4, 1, StudyRecruitStatus.CLOSED);
+
+        mockMvc.perform(patch("/api/studies/{studyId}/reopen", studyPost.getId())
+                        .with(user(new UserDetailsImpl(author))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("RECRUITING"))
+                .andExpect(jsonPath("$.result.statusDisplayName").value("모집중"));
+    }
+
+    @Test
+    void 확정_인원이_가득찬_스터디는_재오픈할_수_없다() throws Exception {
+        User author = saveUser("reopen-full-author@example.com", "작성자");
+        User applicant = saveUser("reopen-full-applicant@example.com", "지원자");
+        StudyPost studyPost = saveStudy(author, "재오픈 불가 테스트", "내용", StudyMode.ONLINE, null, LocalDateTime.now().plusDays(2), 1, 1, StudyRecruitStatus.CLOSED);
+        saveApplication(studyPost, applicant, StudyApplicationStatus.ACCEPTED);
+
+        mockMvc.perform(patch("/api/studies/{studyId}/reopen", studyPost.getId())
+                        .with(user(new UserDetailsImpl(author))))
+                .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.isSuccess").value(false));
     }
 
@@ -373,7 +483,11 @@ class StudyControllerTest {
 
     private StudyApplication saveApplication(StudyPost studyPost, User applicant, StudyApplicationStatus status) {
         StudyApplication application = StudyApplication.create(studyPost, applicant);
-        if (status == StudyApplicationStatus.CANCELED) {
+        if (status == StudyApplicationStatus.ACCEPTED) {
+            application.accept();
+        } else if (status == StudyApplicationStatus.REJECTED) {
+            application.reject();
+        } else if (status == StudyApplicationStatus.CANCELED) {
             application.cancel();
         }
         return studyApplicationRepository.save(application);
@@ -387,5 +501,19 @@ class StudyControllerTest {
             LocalDateTime scheduledAt,
             Integer capacity
     ) {
+    }
+
+    private record UpdateApplicationStatusRequest(
+            String status
+    ) {
+    }
+
+    @TestConfiguration
+    static class TestWebClientConfig {
+
+        @Bean
+        WebClient.Builder webClientBuilder() {
+            return WebClient.builder();
+        }
     }
 }


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요

스터디 상세 화면에서 모집자가 지원자를 확인하고 관리할 수 있도록 백엔드 API를 확장했습니다.

주요 변경 사항:
- 스터디 상세 응답에 모집자 전용 지원자 목록 DTO 추가
- 모집자만 지원자 목록을 조회할 수 있도록 상세 조회 로직 확장
- 모집자가 지원자를 `ACCEPTED` 또는 `REJECTED` 로 처리할 수 있는 API 추가
- 이미 처리된 지원 상태에 대한 중복 변경 방지
- 수락 인원이 정원에 도달하면 모집 상태가 자동으로 `CLOSED` 되도록 처리
- 모집 완료된 스터디를 다시 `RECRUITING` 으로 전환하는 재오픈 API 추가
- 확정 인원이 이미 정원에 도달한 경우 재오픈을 차단하는 검증 추가
- 관련 StudyController 테스트 보강 및 테스트 컨텍스트용 WebClient.Builder 설정 추가

사용자/개발 영향:
- 프론트에서 모집자 상세 화면의 지원자 목록 렌더링과 승인/거절 액션을 실제 API와 연결할 수 있습니다.
- 이후 프론트에서 모집 상태 토글을 붙일 때 재오픈 API를 바로 사용할 수 있습니다.


## 📸 작업 화면 스크린샷

- 백엔드 API 변경으로 별도 화면 스크린샷은 없습니다.


## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

로컬 테스트:
- `bash ./gradlew test --tests com.roddy.domain.study.controller.StudyControllerTest`

## 🚨 관련 이슈 번호 [ #18 ]
close : #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Study authors can view applicant details and application statuses on study pages.
  * Authors can accept or reject applications.
  * Accepted applications may close recruitment when capacity is reached.
  * Closed studies can be reopened when space is available.
  * Applicants can reapply after canceling an application.
* **Validation**
  * Prevented duplicate application processing and invalid status changes.
  * Added checks for recruitment capacity and reopening eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->