### PR TITLE
커뮤니티 백엔드 확장 및 응답 스펙 정렬

### DIFF
--- a/roddy/src/main/java/com/roddy/domain/community/controller/CommunityCommentController.java
+++ b/roddy/src/main/java/com/roddy/domain/community/controller/CommunityCommentController.java
@@ -1,0 +1,55 @@
+package com.roddy.domain.community.controller;
+
+import com.roddy.domain.community.dto.response.ReportPostResponse;
+import com.roddy.domain.community.service.CommunityPostService;
+import com.roddy.global.apiPayload.ApiResponse;
+import com.roddy.global.apiPayload.code.GeneralErrorCode;
+import com.roddy.global.apiPayload.exception.GeneralException;
+import com.roddy.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/community/comments")
+@RequiredArgsConstructor
+@Tag(name = "Community Comment", description = "커뮤니티 댓글 액션 API")
+public class CommunityCommentController {
+
+    private final CommunityPostService communityPostService;
+
+    @DeleteMapping("/{commentId}")
+    @Operation(summary = "댓글 삭제")
+    public ApiResponse<Void> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        communityPostService.deleteComment(commentId, requireUser(userDetails));
+        return ApiResponse.onSuccess("댓글이 삭제되었습니다.");
+    }
+
+    @PostMapping("/{commentId}/report")
+    @Operation(summary = "댓글 신고")
+    public ApiResponse<ReportPostResponse> reportComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return ApiResponse.onSuccess(
+                "댓글이 신고되었습니다.",
+                communityPostService.reportComment(commentId, requireUser(userDetails))
+        );
+    }
+
+    private Long requireUser(UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new GeneralException(GeneralErrorCode.MISSING_AUTH_INFO);
+        }
+        return userDetails.getUser().getId();
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/community/controller/CommunityPostController.java
+++ b/roddy/src/main/java/com/roddy/domain/community/controller/CommunityPostController.java
@@ -68,6 +68,17 @@ public class CommunityPostController {
         );
     }
 
+    @GetMapping("/{postId}/comments")
+    @Operation(summary = "댓글 목록 조회")
+    public ApiResponse<java.util.List<CommunityCommentResponse>> getComments(
+            @PathVariable Long postId
+    ) {
+        return ApiResponse.onSuccess(
+                "댓글 목록을 조회했습니다.",
+                communityPostService.getComments(postId)
+        );
+    }
+
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "커뮤니티 게시글 작성")
     public ApiResponse<CreateCommunityPostResponse> createPost(

--- a/roddy/src/main/java/com/roddy/domain/community/dto/request/CommunityPostSearchCondition.java
+++ b/roddy/src/main/java/com/roddy/domain/community/dto/request/CommunityPostSearchCondition.java
@@ -13,6 +13,6 @@ public class CommunityPostSearchCondition {
     private CommunityJobCategory jobCategory;
     private String keyword;
     private String company;
-    private String position;
+    private String jobRole;
     private String techStack;
 }

--- a/roddy/src/main/java/com/roddy/domain/community/dto/request/CreateCommunityCommentRequest.java
+++ b/roddy/src/main/java/com/roddy/domain/community/dto/request/CreateCommunityCommentRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public record CreateCommunityCommentRequest(
         @NotBlank
-        String content
+        String content,
+        Long parentCommentId
 ) {
 }

--- a/roddy/src/main/java/com/roddy/domain/community/dto/request/CreateCommunityPostRequest.java
+++ b/roddy/src/main/java/com/roddy/domain/community/dto/request/CreateCommunityPostRequest.java
@@ -1,6 +1,7 @@
 package com.roddy.domain.community.dto.request;
 
 import com.roddy.domain.community.enums.CommunityJobCategory;
+import com.roddy.domain.community.enums.CommunityInterviewSubtype;
 import com.roddy.domain.community.enums.CommunityPostCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -26,11 +27,48 @@ public class CreateCommunityPostRequest {
     @NotBlank
     private String content;
 
+    private List<String> tags;
+
+    private String roadmapId;
+
+    private String roadmapTitle;
+
+    private String summary;
+
+    private String description;
+
+    private String targetJob;
+
+    private String targetCompany;
+
+    private List<String> recommendedSkills;
+
+    /**
+     * multipart/form-data에서 단계 정보를 보낼 수 있도록 JSON 문자열로 받습니다.
+     */
+    private String roadmapStepsJson;
+
+    private CommunityInterviewSubtype interviewSubtype;
+
     private String company;
+
+    private String jobRole;
 
     private String position;
 
+    private String preparationPeriod;
+
     private List<String> techStacks;
+
+    private String processSummary;
+
+    private String background;
+
+    private String preparationProcess;
+
+    private String experienceDetail;
+
+    private String advice;
 
     private List<MultipartFile> images;
 }

--- a/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityCommentResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityCommentResponse.java
@@ -6,6 +6,8 @@ public record CommunityCommentResponse(
         Long id,
         String content,
         String authorName,
+        Long parentId,
+        int depth,
         LocalDate createdAt
 ) {
 }

--- a/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityCommentResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityCommentResponse.java
@@ -1,13 +1,13 @@
 package com.roddy.domain.community.dto.response;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record CommunityCommentResponse(
         Long id,
+        String author,
         String content,
-        String authorName,
         Long parentId,
         int depth,
-        LocalDate createdAt
+        LocalDateTime createdAt
 ) {
 }

--- a/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityPostDetailResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityPostDetailResponse.java
@@ -1,24 +1,39 @@
 package com.roddy.domain.community.dto.response;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public record CommunityPostDetailResponse(
         Long id,
-        String postCategory,
-        String postCategoryDisplayName,
-        String jobCategory,
-        String jobCategoryDisplayName,
+        String type,
+        String tag,
+        List<String> tags,
         String title,
         String content,
         String authorName,
-        LocalDate createdAt,
-        int viewCount,
-        int likeCount,
+        java.time.LocalDateTime createdAt,
+        int views,
+        int likes,
+        int commentCount,
         boolean liked,
+        String excerpt,
+        String roadmapId,
+        String roadmapTitle,
+        String summary,
+        String targetJob,
+        String targetCompany,
+        List<String> recommendedSkills,
+        List<CommunityRoadmapStepResponse> roadmapSteps,
+        String description,
+        String subtype,
         String company,
-        String position,
+        String jobRole,
+        String preparationPeriod,
         List<String> techStacks,
+        String processSummary,
+        String background,
+        String preparationProcess,
+        String experienceDetail,
+        String advice,
         List<String> imageUrls,
         List<CommunityCommentResponse> comments
 ) {

--- a/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityPostListItemResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityPostListItemResponse.java
@@ -1,20 +1,38 @@
 package com.roddy.domain.community.dto.response;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public record CommunityPostListItemResponse(
         Long id,
-        String postCategory,
-        String postCategoryDisplayName,
-        String jobCategory,
-        String jobCategoryDisplayName,
+        String type,
+        String tag,
+        List<String> tags,
         String title,
         String authorName,
-        LocalDate createdAt,
-        int viewCount,
-        int likeCount,
+        LocalDateTime createdAt,
+        int views,
+        int likes,
+        int commentCount,
+        String excerpt,
+        String content,
+        String roadmapId,
+        String roadmapTitle,
+        String summary,
+        String targetJob,
+        String targetCompany,
+        List<String> recommendedSkills,
+        List<CommunityRoadmapStepResponse> roadmapSteps,
+        String description,
+        String subtype,
         String company,
-        String position,
-        java.util.List<String> techStacks
+        String jobRole,
+        String preparationPeriod,
+        List<String> techStacks,
+        String processSummary,
+        String background,
+        String preparationProcess,
+        String experienceDetail,
+        String advice
 ) {
 }

--- a/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityRoadmapStepResponse.java
+++ b/roddy/src/main/java/com/roddy/domain/community/dto/response/CommunityRoadmapStepResponse.java
@@ -1,0 +1,11 @@
+package com.roddy.domain.community.dto.response;
+
+import java.util.List;
+
+public record CommunityRoadmapStepResponse(
+        String stage,
+        String goal,
+        List<String> topics,
+        List<String> outputs
+) {
+}

--- a/roddy/src/main/java/com/roddy/domain/community/entity/CommunityComment.java
+++ b/roddy/src/main/java/com/roddy/domain/community/entity/CommunityComment.java
@@ -10,12 +10,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -41,11 +45,37 @@ public class CommunityComment extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    public static CommunityComment create(CommunityPost post, User author, String content) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private CommunityComment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", cascade = jakarta.persistence.CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CommunityComment> replies = new ArrayList<>();
+
+    public static CommunityComment create(CommunityPost post, User author, String content, CommunityComment parentComment) {
+        if (parentComment != null && !parentComment.getPost().getId().equals(post.getId())) {
+            throw new IllegalArgumentException("대댓글의 부모 댓글은 같은 게시글에 속해야 합니다.");
+        }
+
         return CommunityComment.builder()
                 .post(post)
                 .author(author)
                 .content(content)
+                .parentComment(parentComment)
+                .replies(new ArrayList<>())
                 .build();
+    }
+
+    public boolean isReply() {
+        return parentComment != null;
+    }
+
+    public boolean isAuthor(Long userId) {
+        return author != null && author.getId().equals(userId);
+    }
+
+    public int getDepth() {
+        return isReply() ? 1 : 0;
     }
 }

--- a/roddy/src/main/java/com/roddy/domain/community/entity/CommunityCommentReport.java
+++ b/roddy/src/main/java/com/roddy/domain/community/entity/CommunityCommentReport.java
@@ -1,0 +1,58 @@
+package com.roddy.domain.community.entity;
+
+import com.roddy.domain.BaseEntity;
+import com.roddy.domain.auth.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Table(
+        name = "community_comment_reports",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_community_comment_report_comment_user",
+                columnNames = {"community_comment_id", "user_id"}
+        )
+)
+public class CommunityCommentReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "community_comment_report_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "community_comment_id", nullable = false)
+    private CommunityComment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(columnDefinition = "TEXT")
+    private String reason;
+
+    public static CommunityCommentReport create(CommunityComment comment, User user, String reason) {
+        return CommunityCommentReport.builder()
+                .comment(comment)
+                .user(user)
+                .reason(reason)
+                .build();
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/community/entity/CommunityInterviewPostDetail.java
+++ b/roddy/src/main/java/com/roddy/domain/community/entity/CommunityInterviewPostDetail.java
@@ -1,0 +1,135 @@
+package com.roddy.domain.community.entity;
+
+import com.roddy.domain.community.enums.CommunityInterviewSubtype;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Table(name = "community_interview_post_details")
+public class CommunityInterviewPostDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "community_interview_post_detail_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "community_post_id", nullable = false, unique = true)
+    private CommunityPost post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private CommunityInterviewSubtype subtype;
+
+    @Column(nullable = false)
+    private String company;
+
+    @Column(nullable = false)
+    private String jobRole;
+
+    @Column(nullable = false)
+    private String preparationPeriod;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "community_interview_post_tech_stacks",
+            joinColumns = @JoinColumn(name = "community_interview_post_detail_id")
+    )
+    @Column(name = "tech_stack", nullable = false)
+    @Builder.Default
+    private Set<String> techStacks = new LinkedHashSet<>();
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String processSummary;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String background;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String preparationProcess;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String experienceDetail;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String advice;
+
+    public static CommunityInterviewPostDetail create(
+            CommunityPost post,
+            CommunityInterviewSubtype subtype,
+            String company,
+            String jobRole,
+            String preparationPeriod,
+            List<String> techStacks,
+            String processSummary,
+            String background,
+            String preparationProcess,
+            String experienceDetail,
+            String advice
+    ) {
+        return CommunityInterviewPostDetail.builder()
+                .post(post)
+                .subtype(subtype)
+                .company(requireText(company))
+                .jobRole(requireText(jobRole))
+                .preparationPeriod(defaultIfBlank(preparationPeriod, "미입력"))
+                .techStacks(normalizeValues(techStacks))
+                .processSummary(defaultIfBlank(processSummary, ""))
+                .background(defaultIfBlank(background, ""))
+                .preparationProcess(defaultIfBlank(preparationProcess, ""))
+                .experienceDetail(defaultIfBlank(experienceDetail, ""))
+                .advice(defaultIfBlank(advice, ""))
+                .build();
+    }
+
+    private static String requireText(String value) {
+        String trimmed = defaultIfBlank(value, null);
+        if (trimmed == null) {
+            throw new IllegalArgumentException("필수 인터뷰 상세 값이 누락되었습니다.");
+        }
+        return trimmed;
+    }
+
+    private static String defaultIfBlank(String value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? defaultValue : trimmed;
+    }
+
+    private static Set<String> normalizeValues(List<String> values) {
+        if (values == null) {
+            return new LinkedHashSet<>();
+        }
+        return values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/community/entity/CommunityPost.java
+++ b/roddy/src/main/java/com/roddy/domain/community/entity/CommunityPost.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -61,18 +63,14 @@ public class CommunityPost extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    private String company;
-
-    private String position;
-
     @ElementCollection
     @CollectionTable(
-            name = "community_post_tech_stacks",
+            name = "community_post_tags",
             joinColumns = @JoinColumn(name = "community_post_id")
     )
-    @Column(name = "tech_stack", nullable = false)
+    @Column(name = "tag", nullable = false)
     @Builder.Default
-    private Set<String> techStacks = new LinkedHashSet<>();
+    private Set<String> tags = new LinkedHashSet<>();
 
     @Column(nullable = false)
     private int viewCount;
@@ -87,15 +85,19 @@ public class CommunityPost extends BaseEntity {
     @Builder.Default
     private List<CommunityPostImage> images = new ArrayList<>();
 
+    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private CommunityRoadmapPostDetail roadmapDetail;
+
+    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private CommunityInterviewPostDetail interviewDetail;
+
     public static CommunityPost create(
             User author,
             CommunityPostCategory postCategory,
             CommunityJobCategory jobCategory,
             String title,
             String content,
-            String company,
-            String position,
-            List<String> techStacks
+            List<String> tags
     ) {
         return CommunityPost.builder()
                 .author(author)
@@ -103,9 +105,7 @@ public class CommunityPost extends BaseEntity {
                 .jobCategory(jobCategory)
                 .title(title)
                 .content(content)
-                .company(normalizeOptional(company))
-                .position(normalizeOptional(position))
-                .techStacks(normalizeTechStacks(techStacks))
+                .tags(normalizeTags(tags))
                 .viewCount(0)
                 .likeCount(0)
                 .reportCount(0)
@@ -135,21 +135,33 @@ public class CommunityPost extends BaseEntity {
         this.images.add(image);
     }
 
-    private static String normalizeOptional(String value) {
-        if (value == null) {
-            return null;
-        }
-        String trimmed = value.trim();
-        return trimmed.isBlank() ? null : trimmed;
+    public void attachRoadmapDetail(CommunityRoadmapPostDetail roadmapDetail) {
+        this.roadmapDetail = roadmapDetail;
     }
 
-    private static Set<String> normalizeTechStacks(List<String> techStacks) {
-        if (techStacks == null) {
+    public void attachInterviewDetail(CommunityInterviewPostDetail interviewDetail) {
+        this.interviewDetail = interviewDetail;
+    }
+
+    public boolean isGeneralPost() {
+        return postCategory == CommunityPostCategory.FREE;
+    }
+
+    public boolean isRoadmapPost() {
+        return postCategory == CommunityPostCategory.ROADMAP;
+    }
+
+    public boolean isInterviewPost() {
+        return postCategory == CommunityPostCategory.PASS_REVIEW_INTERVIEW;
+    }
+
+    private static Set<String> normalizeTags(List<String> tags) {
+        if (tags == null) {
             return new LinkedHashSet<>();
         }
-        return techStacks.stream()
-                .filter(stack -> stack != null && !stack.isBlank())
+        return tags.stream()
+                .filter(tag -> tag != null && !tag.isBlank())
                 .map(String::trim)
-                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/roddy/src/main/java/com/roddy/domain/community/entity/CommunityRoadmapPostDetail.java
+++ b/roddy/src/main/java/com/roddy/domain/community/entity/CommunityRoadmapPostDetail.java
@@ -1,0 +1,140 @@
+package com.roddy.domain.community.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Table(name = "community_roadmap_post_details")
+public class CommunityRoadmapPostDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "community_roadmap_post_detail_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "community_post_id", nullable = false, unique = true)
+    private CommunityPost post;
+
+    private String roadmapId;
+
+    @Column(nullable = false)
+    private String roadmapTitle;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String summary;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String targetJob;
+
+    private String targetCompany;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "community_roadmap_post_recommended_skills",
+            joinColumns = @JoinColumn(name = "community_roadmap_post_detail_id")
+    )
+    @Column(name = "recommended_skill", nullable = false)
+    @Builder.Default
+    private Set<String> recommendedSkills = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "roadmapDetail", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("displayOrder asc")
+    @Builder.Default
+    private List<CommunityRoadmapPostStep> roadmapSteps = new ArrayList<>();
+
+    public static CommunityRoadmapPostDetail create(
+            CommunityPost post,
+            String roadmapId,
+            String roadmapTitle,
+            String summary,
+            String description,
+            String targetJob,
+            String targetCompany,
+            List<String> recommendedSkills
+    ) {
+        return CommunityRoadmapPostDetail.builder()
+                .post(post)
+                .roadmapId(normalizeNullable(roadmapId))
+                .roadmapTitle(requireText(roadmapTitle))
+                .summary(defaultIfBlank(summary, ""))
+                .description(defaultIfBlank(description, ""))
+                .targetJob(requireText(targetJob))
+                .targetCompany(normalizeNullable(targetCompany))
+                .recommendedSkills(normalizeValues(recommendedSkills))
+                .roadmapSteps(new ArrayList<>())
+                .build();
+    }
+
+    public void replaceSteps(List<CommunityRoadmapPostStep> steps) {
+        this.roadmapSteps.clear();
+        if (steps != null) {
+            steps.forEach(this::addStep);
+        }
+    }
+
+    public void addStep(CommunityRoadmapPostStep step) {
+        this.roadmapSteps.add(step);
+    }
+
+    private static String requireText(String value) {
+        String trimmed = normalizeNullable(value);
+        if (trimmed == null) {
+            throw new IllegalArgumentException("필수 로드맵 상세 값이 누락되었습니다.");
+        }
+        return trimmed;
+    }
+
+    private static String defaultIfBlank(String value, String defaultValue) {
+        String normalized = normalizeNullable(value);
+        return normalized == null ? defaultValue : normalized;
+    }
+
+    private static String normalizeNullable(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? null : trimmed;
+    }
+
+    private static Set<String> normalizeValues(List<String> values) {
+        if (values == null) {
+            return new LinkedHashSet<>();
+        }
+        return values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/community/entity/CommunityRoadmapPostStep.java
+++ b/roddy/src/main/java/com/roddy/domain/community/entity/CommunityRoadmapPostStep.java
@@ -1,0 +1,94 @@
+package com.roddy.domain.community.entity;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Table(name = "community_roadmap_post_steps")
+public class CommunityRoadmapPostStep {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "community_roadmap_post_step_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "community_roadmap_post_detail_id", nullable = false)
+    private CommunityRoadmapPostDetail roadmapDetail;
+
+    @Column(nullable = false)
+    private int displayOrder;
+
+    @Column(nullable = false)
+    private String stage;
+
+    @Column(nullable = false)
+    private String goal;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "community_roadmap_post_step_topics",
+            joinColumns = @JoinColumn(name = "community_roadmap_post_step_id")
+    )
+    @Column(name = "topic", nullable = false)
+    @Builder.Default
+    private List<String> topics = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(
+            name = "community_roadmap_post_step_outputs",
+            joinColumns = @JoinColumn(name = "community_roadmap_post_step_id")
+    )
+    @Column(name = "output", nullable = false)
+    @Builder.Default
+    private List<String> outputs = new ArrayList<>();
+
+    public static CommunityRoadmapPostStep create(
+            CommunityRoadmapPostDetail roadmapDetail,
+            int displayOrder,
+            String stage,
+            String goal,
+            List<String> topics,
+            List<String> outputs
+    ) {
+        return CommunityRoadmapPostStep.builder()
+                .roadmapDetail(roadmapDetail)
+                .displayOrder(displayOrder)
+                .stage(stage == null ? "" : stage.trim())
+                .goal(goal == null ? "" : goal.trim())
+                .topics(normalizeValues(topics))
+                .outputs(normalizeValues(outputs))
+                .build();
+    }
+
+    private static List<String> normalizeValues(List<String> values) {
+        if (values == null) {
+            return new ArrayList<>();
+        }
+        return values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .toList();
+    }
+}

--- a/roddy/src/main/java/com/roddy/domain/community/enums/CommunityInterviewSubtype.java
+++ b/roddy/src/main/java/com/roddy/domain/community/enums/CommunityInterviewSubtype.java
@@ -1,0 +1,13 @@
+package com.roddy.domain.community.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommunityInterviewSubtype {
+    ACCEPTED("합격 후기"),
+    INCUMBENT("현직자 인터뷰");
+
+    private final String displayName;
+}

--- a/roddy/src/main/java/com/roddy/domain/community/repository/CommunityCommentReportRepository.java
+++ b/roddy/src/main/java/com/roddy/domain/community/repository/CommunityCommentReportRepository.java
@@ -1,0 +1,9 @@
+package com.roddy.domain.community.repository;
+
+import com.roddy.domain.community.entity.CommunityCommentReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunityCommentReportRepository extends JpaRepository<CommunityCommentReport, Long> {
+
+    boolean existsByComment_IdAndUser_Id(Long commentId, Long userId);
+}

--- a/roddy/src/main/java/com/roddy/domain/community/repository/CommunityCommentRepository.java
+++ b/roddy/src/main/java/com/roddy/domain/community/repository/CommunityCommentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
 
@@ -13,7 +14,14 @@ public interface CommunityCommentRepository extends JpaRepository<CommunityComme
             from CommunityComment c
             join fetch c.author
             where c.post.id = :postId
-            order by c.createdAt asc
+            order by
+                case when c.parentComment is null then c.id else c.parentComment.id end asc,
+                case when c.parentComment is null then 0 else 1 end asc,
+                c.createdAt asc
             """)
-    List<CommunityComment> findAllByPostIdOrderByCreatedAtAsc(Long postId);
+    List<CommunityComment> findAllByPostIdOrderByThread(Long postId);
+
+    Optional<CommunityComment> findByIdAndPost_Id(Long commentId, Long postId);
+
+    long countByPost_Id(Long postId);
 }

--- a/roddy/src/main/java/com/roddy/domain/community/repository/CommunityPostRepositoryImpl.java
+++ b/roddy/src/main/java/com/roddy/domain/community/repository/CommunityPostRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.roddy.domain.community.repository;
 
 import com.roddy.domain.community.dto.request.CommunityPostSearchCondition;
+import com.roddy.domain.community.entity.CommunityInterviewPostDetail;
 import com.roddy.domain.community.entity.CommunityPost;
+import com.roddy.domain.community.entity.CommunityRoadmapPostDetail;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
@@ -36,9 +38,12 @@ public class CommunityPostRepositoryImpl implements CommunityPostRepositoryCusto
         CriteriaQuery<Long> idQuery = cb.createQuery(Long.class);
         Root<CommunityPost> root = idQuery.from(CommunityPost.class);
         root.join("author", JoinType.INNER);
-        Join<CommunityPost, String> techStacks = root.join("techStacks", JoinType.LEFT);
+        Join<CommunityPost, CommunityRoadmapPostDetail> roadmapDetail = root.join("roadmapDetail", JoinType.LEFT);
+        Join<CommunityRoadmapPostDetail, String> roadmapSkills = roadmapDetail.join("recommendedSkills", JoinType.LEFT);
+        Join<CommunityPost, CommunityInterviewPostDetail> interviewDetail = root.join("interviewDetail", JoinType.LEFT);
+        Join<CommunityInterviewPostDetail, String> interviewSkills = interviewDetail.join("techStacks", JoinType.LEFT);
 
-        List<Predicate> predicates = buildPredicates(condition, cb, root, techStacks);
+        List<Predicate> predicates = buildPredicates(condition, cb, root, roadmapDetail, roadmapSkills, interviewDetail, interviewSkills);
         idQuery.select(root.get("id")).distinct(true);
         idQuery.where(predicates.toArray(Predicate[]::new));
         idQuery.orderBy(buildOrders(cb, root, pageable));
@@ -64,7 +69,8 @@ public class CommunityPostRepositoryImpl implements CommunityPostRepositoryCusto
                         select distinct p
                         from CommunityPost p
                         join fetch p.author
-                        left join fetch p.techStacks
+                        left join fetch p.roadmapDetail
+                        left join fetch p.interviewDetail
                         where p.id in :ids
                         """, CommunityPost.class)
                 .setParameter("ids", ids)
@@ -78,7 +84,8 @@ public class CommunityPostRepositoryImpl implements CommunityPostRepositoryCusto
                         from CommunityPost p
                         join fetch p.author
                         left join fetch p.images
-                        left join fetch p.techStacks
+                        left join fetch p.roadmapDetail
+                        left join fetch p.interviewDetail
                         where p.id = :id
                         """, CommunityPost.class)
                 .setParameter("id", id)
@@ -92,9 +99,12 @@ public class CommunityPostRepositoryImpl implements CommunityPostRepositoryCusto
         CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
         Root<CommunityPost> root = countQuery.from(CommunityPost.class);
         root.join("author", JoinType.INNER);
-        Join<CommunityPost, String> techStacks = root.join("techStacks", JoinType.LEFT);
+        Join<CommunityPost, CommunityRoadmapPostDetail> roadmapDetail = root.join("roadmapDetail", JoinType.LEFT);
+        Join<CommunityRoadmapPostDetail, String> roadmapSkills = roadmapDetail.join("recommendedSkills", JoinType.LEFT);
+        Join<CommunityPost, CommunityInterviewPostDetail> interviewDetail = root.join("interviewDetail", JoinType.LEFT);
+        Join<CommunityInterviewPostDetail, String> interviewSkills = interviewDetail.join("techStacks", JoinType.LEFT);
 
-        List<Predicate> predicates = buildPredicates(condition, cb, root, techStacks);
+        List<Predicate> predicates = buildPredicates(condition, cb, root, roadmapDetail, roadmapSkills, interviewDetail, interviewSkills);
         countQuery.select(cb.countDistinct(root));
         countQuery.where(predicates.toArray(Predicate[]::new));
         return entityManager.createQuery(countQuery).getSingleResult();
@@ -104,7 +114,10 @@ public class CommunityPostRepositoryImpl implements CommunityPostRepositoryCusto
             CommunityPostSearchCondition condition,
             CriteriaBuilder cb,
             Root<CommunityPost> root,
-            Join<CommunityPost, String> techStacks
+            Join<CommunityPost, CommunityRoadmapPostDetail> roadmapDetail,
+            Join<CommunityRoadmapPostDetail, String> roadmapSkills,
+            Join<CommunityPost, CommunityInterviewPostDetail> interviewDetail,
+            Join<CommunityInterviewPostDetail, String> interviewSkills
     ) {
         List<Predicate> predicates = new ArrayList<>();
 
@@ -118,19 +131,35 @@ public class CommunityPostRepositoryImpl implements CommunityPostRepositoryCusto
             String keyword = toLikePattern(condition.getKeyword());
             predicates.add(cb.or(
                     cb.like(cb.lower(root.get("title")), keyword),
-                    cb.like(cb.lower(cb.coalesce(root.get("company"), "")), keyword),
-                    cb.like(cb.lower(cb.coalesce(root.get("position"), "")), keyword),
-                    cb.like(cb.lower(techStacks), keyword)
+                    cb.like(cb.lower(root.get("content")), keyword),
+                    cb.like(cb.lower(cb.coalesce(roadmapDetail.get("targetCompany"), "")), keyword),
+                    cb.like(cb.lower(cb.coalesce(roadmapDetail.get("targetJob"), "")), keyword),
+                    cb.like(cb.lower(roadmapSkills), keyword),
+                    cb.like(cb.lower(cb.coalesce(interviewDetail.get("company"), "")), keyword),
+                    cb.like(cb.lower(cb.coalesce(interviewDetail.get("jobRole"), "")), keyword),
+                    cb.like(cb.lower(interviewSkills), keyword)
             ));
         }
         if (StringUtils.hasText(condition.getCompany())) {
-            predicates.add(cb.like(cb.lower(cb.coalesce(root.get("company"), "")), toLikePattern(condition.getCompany())));
+            String company = toLikePattern(condition.getCompany());
+            predicates.add(cb.or(
+                    cb.like(cb.lower(cb.coalesce(roadmapDetail.get("targetCompany"), "")), company),
+                    cb.like(cb.lower(cb.coalesce(interviewDetail.get("company"), "")), company)
+            ));
         }
-        if (StringUtils.hasText(condition.getPosition())) {
-            predicates.add(cb.like(cb.lower(cb.coalesce(root.get("position"), "")), toLikePattern(condition.getPosition())));
+        if (StringUtils.hasText(condition.getJobRole())) {
+            String jobRole = toLikePattern(condition.getJobRole());
+            predicates.add(cb.or(
+                    cb.like(cb.lower(cb.coalesce(roadmapDetail.get("targetJob"), "")), jobRole),
+                    cb.like(cb.lower(cb.coalesce(interviewDetail.get("jobRole"), "")), jobRole)
+            ));
         }
         if (StringUtils.hasText(condition.getTechStack())) {
-            predicates.add(cb.like(cb.lower(techStacks), toLikePattern(condition.getTechStack())));
+            String techStack = toLikePattern(condition.getTechStack());
+            predicates.add(cb.or(
+                    cb.like(cb.lower(roadmapSkills), techStack),
+                    cb.like(cb.lower(interviewSkills), techStack)
+            ));
         }
 
         return predicates;

--- a/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
+++ b/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
@@ -13,14 +13,18 @@ import com.roddy.domain.community.dto.response.CreateCommunityPostResponse;
 import com.roddy.domain.community.dto.response.ReportPostResponse;
 import com.roddy.domain.community.dto.response.TogglePostLikeResponse;
 import com.roddy.domain.community.entity.CommunityComment;
+import com.roddy.domain.community.entity.CommunityInterviewPostDetail;
 import com.roddy.domain.community.entity.CommunityPost;
 import com.roddy.domain.community.entity.CommunityPostImage;
 import com.roddy.domain.community.entity.CommunityPostLike;
 import com.roddy.domain.community.entity.CommunityPostReport;
+import com.roddy.domain.community.entity.CommunityRoadmapPostDetail;
 import com.roddy.domain.community.repository.CommunityCommentRepository;
 import com.roddy.domain.community.repository.CommunityPostLikeRepository;
 import com.roddy.domain.community.repository.CommunityPostReportRepository;
 import com.roddy.domain.community.repository.CommunityPostRepository;
+import com.roddy.domain.community.enums.CommunityInterviewSubtype;
+import com.roddy.domain.community.enums.CommunityPostCategory;
 import com.roddy.global.apiPayload.code.GeneralErrorCode;
 import com.roddy.global.apiPayload.exception.GeneralException;
 import com.roddy.global.config.s3.S3Uploader;
@@ -76,7 +80,7 @@ public class CommunityPostService {
         CommunityPost post = getPostOrThrow(postId);
         post.increaseViewCount();
 
-        List<CommunityCommentResponse> comments = communityCommentRepository.findAllByPostIdOrderByCreatedAtAsc(postId)
+        List<CommunityCommentResponse> comments = communityCommentRepository.findAllByPostIdOrderByThread(postId)
                 .stream()
                 .map(this::toCommentResponse)
                 .toList();
@@ -96,9 +100,9 @@ public class CommunityPostService {
                 post.getViewCount(),
                 post.getLikeCount(),
                 liked,
-                post.getCompany(),
-                post.getPosition(),
-                new ArrayList<>(post.getTechStacks()),
+                extractCompany(post),
+                extractJobRole(post),
+                extractTechStacks(post),
                 post.getImages().stream().map(CommunityPostImage::getImageUrl).toList(),
                 comments
         );
@@ -113,10 +117,9 @@ public class CommunityPostService {
                 request.getJobCategory(),
                 request.getTitle().trim(),
                 request.getContent().trim(),
-                request.getCompany(),
-                request.getPosition(),
-                request.getTechStacks()
+                List.of()
         );
+        attachInitialDetail(post, request);
 
         List<String> uploadedImageUrls = new ArrayList<>();
         try {
@@ -184,9 +187,10 @@ public class CommunityPostService {
     public CommunityCommentResponse createComment(Long postId, Long userId, CreateCommunityCommentRequest request) {
         CommunityPost post = getPostOrThrow(postId);
         User author = getUserOrThrow(userId);
+        CommunityComment parentComment = resolveParentComment(postId, request.parentCommentId());
 
         CommunityComment comment = communityCommentRepository.save(
-                CommunityComment.create(post, author, request.content().trim())
+                CommunityComment.create(post, author, request.content().trim(), parentComment)
         );
 
         return toCommentResponse(comment);
@@ -214,9 +218,9 @@ public class CommunityPostService {
                 toLocalDate(post.getCreatedAt()),
                 post.getViewCount(),
                 post.getLikeCount(),
-                post.getCompany(),
-                post.getPosition(),
-                new ArrayList<>(post.getTechStacks())
+                extractCompany(post),
+                extractJobRole(post),
+                extractTechStacks(post)
         );
     }
 
@@ -225,8 +229,95 @@ public class CommunityPostService {
                 comment.getId(),
                 comment.getContent(),
                 comment.getAuthor().getNickname(),
+                comment.getParentComment() == null ? null : comment.getParentComment().getId(),
+                comment.getDepth(),
                 toLocalDate(comment.getCreatedAt())
         );
+    }
+
+    private void attachInitialDetail(CommunityPost post, CreateCommunityPostRequest request) {
+        if (post.getPostCategory() == CommunityPostCategory.ROADMAP) {
+            post.attachRoadmapDetail(CommunityRoadmapPostDetail.create(
+                    post,
+                    null,
+                    post.getTitle(),
+                    post.getContent(),
+                    post.getContent(),
+                    defaultIfBlank(request.getPosition(), post.getJobCategory().getDisplayName()),
+                    request.getCompany(),
+                    request.getTechStacks()
+            ));
+            return;
+        }
+
+        if (post.getPostCategory() == CommunityPostCategory.PASS_REVIEW_INTERVIEW) {
+            post.attachInterviewDetail(CommunityInterviewPostDetail.create(
+                    post,
+                    CommunityInterviewSubtype.ACCEPTED,
+                    defaultIfBlank(request.getCompany(), "미입력"),
+                    defaultIfBlank(request.getPosition(), post.getJobCategory().getDisplayName()),
+                    "미입력",
+                    request.getTechStacks(),
+                    post.getContent(),
+                    "",
+                    "",
+                    "",
+                    ""
+            ));
+        }
+    }
+
+    private CommunityComment resolveParentComment(Long postId, Long parentCommentId) {
+        if (parentCommentId == null) {
+            return null;
+        }
+
+        CommunityComment parentComment = communityCommentRepository.findByIdAndPost_Id(parentCommentId, postId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.COMMUNITY_COMMENT_NOT_FOUND));
+
+        if (parentComment.isReply()) {
+            throw new GeneralException(GeneralErrorCode.COMMUNITY_COMMENT_PARENT_INVALID);
+        }
+
+        return parentComment;
+    }
+
+    private String extractCompany(CommunityPost post) {
+        if (post.getRoadmapDetail() != null) {
+            return post.getRoadmapDetail().getTargetCompany();
+        }
+        if (post.getInterviewDetail() != null) {
+            return post.getInterviewDetail().getCompany();
+        }
+        return null;
+    }
+
+    private String extractJobRole(CommunityPost post) {
+        if (post.getRoadmapDetail() != null) {
+            return post.getRoadmapDetail().getTargetJob();
+        }
+        if (post.getInterviewDetail() != null) {
+            return post.getInterviewDetail().getJobRole();
+        }
+        return null;
+    }
+
+    private List<String> extractTechStacks(CommunityPost post) {
+        if (post.getRoadmapDetail() != null) {
+            return new ArrayList<>(post.getRoadmapDetail().getRecommendedSkills());
+        }
+        if (post.getInterviewDetail() != null) {
+            return new ArrayList<>(post.getInterviewDetail().getTechStacks());
+        }
+        return List.of();
+    }
+
+    private String defaultIfBlank(String value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? defaultValue : trimmed;
     }
 
     private LocalDate toLocalDate(java.time.LocalDateTime dateTime) {

--- a/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
+++ b/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
@@ -1,5 +1,8 @@
 package com.roddy.domain.community.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.roddy.domain.auth.entity.User;
 import com.roddy.domain.auth.repository.UserRepository;
 import com.roddy.domain.community.dto.request.CommunityPostSearchCondition;
@@ -20,6 +23,7 @@ import com.roddy.domain.community.entity.CommunityPostImage;
 import com.roddy.domain.community.entity.CommunityPostLike;
 import com.roddy.domain.community.entity.CommunityPostReport;
 import com.roddy.domain.community.entity.CommunityRoadmapPostDetail;
+import com.roddy.domain.community.entity.CommunityRoadmapPostStep;
 import com.roddy.domain.community.repository.CommunityCommentRepository;
 import com.roddy.domain.community.repository.CommunityCommentReportRepository;
 import com.roddy.domain.community.repository.CommunityPostLikeRepository;
@@ -43,6 +47,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -61,6 +66,7 @@ public class CommunityPostService {
     private final CommunityPostReportRepository communityPostReportRepository;
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
+    private final ObjectMapper objectMapper;
 
     @Transactional(readOnly = true)
     public CommunityPostListResponse getPosts(CommunityPostSearchCondition condition, int page, int size, String sort) {
@@ -117,9 +123,9 @@ public class CommunityPostService {
                 request.getJobCategory(),
                 request.getTitle().trim(),
                 request.getContent().trim(),
-                List.of()
+                request.getTags()
         );
-        attachInitialDetail(post, request);
+        attachTypedDetail(post, request);
 
         List<String> uploadedImageUrls = new ArrayList<>();
         try {
@@ -276,34 +282,38 @@ public class CommunityPostService {
         );
     }
 
-    private void attachInitialDetail(CommunityPost post, CreateCommunityPostRequest request) {
+    private void attachTypedDetail(CommunityPost post, CreateCommunityPostRequest request) {
         if (post.getPostCategory() == CommunityPostCategory.ROADMAP) {
-            post.attachRoadmapDetail(CommunityRoadmapPostDetail.create(
+            validateRoadmapRequest(request);
+            CommunityRoadmapPostDetail roadmapDetail = CommunityRoadmapPostDetail.create(
                     post,
-                    null,
-                    post.getTitle(),
-                    post.getContent(),
-                    post.getContent(),
-                    defaultIfBlank(request.getPosition(), post.getJobCategory().getDisplayName()),
-                    request.getCompany(),
-                    request.getTechStacks()
-            ));
+                    request.getRoadmapId(),
+                    defaultIfBlank(request.getRoadmapTitle(), post.getTitle()),
+                    defaultIfBlank(request.getSummary(), post.getContent()),
+                    defaultIfBlank(request.getDescription(), post.getContent()),
+                    defaultIfBlank(request.getTargetJob(), resolveJobRole(request, post.getJobCategory().getDisplayName())),
+                    defaultIfBlank(request.getTargetCompany(), request.getCompany()),
+                    firstNonEmpty(request.getRecommendedSkills(), request.getTechStacks())
+            );
+            roadmapDetail.replaceSteps(parseRoadmapSteps(roadmapDetail, request.getRoadmapStepsJson()));
+            post.attachRoadmapDetail(roadmapDetail);
             return;
         }
 
         if (post.getPostCategory() == CommunityPostCategory.PASS_REVIEW_INTERVIEW) {
+            validateInterviewRequest(request);
             post.attachInterviewDetail(CommunityInterviewPostDetail.create(
                     post,
-                    CommunityInterviewSubtype.ACCEPTED,
+                    request.getInterviewSubtype() == null ? CommunityInterviewSubtype.ACCEPTED : request.getInterviewSubtype(),
                     defaultIfBlank(request.getCompany(), "미입력"),
-                    defaultIfBlank(request.getPosition(), post.getJobCategory().getDisplayName()),
-                    "미입력",
+                    resolveJobRole(request, post.getJobCategory().getDisplayName()),
+                    defaultIfBlank(request.getPreparationPeriod(), "미입력"),
                     request.getTechStacks(),
-                    post.getContent(),
-                    "",
-                    "",
-                    "",
-                    ""
+                    defaultIfBlank(request.getProcessSummary(), post.getContent()),
+                    defaultIfBlank(request.getBackground(), ""),
+                    defaultIfBlank(request.getPreparationProcess(), ""),
+                    defaultIfBlank(request.getExperienceDetail(), ""),
+                    defaultIfBlank(request.getAdvice(), "")
             ));
         }
     }
@@ -359,6 +369,85 @@ public class CommunityPostService {
         }
         String trimmed = value.trim();
         return trimmed.isBlank() ? defaultValue : trimmed;
+    }
+
+    private String resolveJobRole(CreateCommunityPostRequest request, String defaultValue) {
+        return defaultIfBlank(request.getJobRole(), defaultIfBlank(request.getPosition(), defaultValue));
+    }
+
+    private List<String> firstNonEmpty(List<String> primary, List<String> fallback) {
+        return primary != null && !primary.isEmpty() ? primary : fallback;
+    }
+
+    private void validateRoadmapRequest(CreateCommunityPostRequest request) {
+        if (!hasText(request.getTargetJob()) && !hasText(request.getPosition()) && !hasText(request.getJobRole())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "로드맵 글은 목표 직무가 필요합니다.");
+        }
+    }
+
+    private void validateInterviewRequest(CreateCommunityPostRequest request) {
+        if (!hasText(request.getCompany())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "인터뷰 글은 회사명이 필요합니다.");
+        }
+        if (!hasText(request.getJobRole()) && !hasText(request.getPosition())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "인터뷰 글은 직무가 필요합니다.");
+        }
+        if (!hasText(request.getPreparationPeriod())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "인터뷰 글은 준비 기간이 필요합니다.");
+        }
+        if (!hasText(request.getProcessSummary())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "인터뷰 글은 진행 요약이 필요합니다.");
+        }
+        if (!hasText(request.getBackground())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "인터뷰 글은 배경 정보가 필요합니다.");
+        }
+        if (!hasText(request.getPreparationProcess())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "인터뷰 글은 준비 과정이 필요합니다.");
+        }
+        if (!hasText(request.getExperienceDetail())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "인터뷰 글은 상세 경험이 필요합니다.");
+        }
+        if (!hasText(request.getAdvice())) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "인터뷰 글은 조언 항목이 필요합니다.");
+        }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private List<CommunityRoadmapPostStep> parseRoadmapSteps(CommunityRoadmapPostDetail roadmapDetail, String roadmapStepsJson) {
+        if (!hasText(roadmapStepsJson)) {
+            return Collections.emptyList();
+        }
+
+        try {
+            List<RoadmapStepPayload> stepPayloads = objectMapper.readValue(roadmapStepsJson, new TypeReference<>() {
+            });
+            List<CommunityRoadmapPostStep> steps = new ArrayList<>();
+            for (int index = 0; index < stepPayloads.size(); index++) {
+                RoadmapStepPayload payload = stepPayloads.get(index);
+                steps.add(CommunityRoadmapPostStep.create(
+                        roadmapDetail,
+                        index,
+                        defaultIfBlank(payload.stage(), ""),
+                        defaultIfBlank(payload.goal(), ""),
+                        payload.topics(),
+                        payload.outputs()
+                ));
+            }
+            return steps;
+        } catch (JsonProcessingException exception) {
+            throw new GeneralException(GeneralErrorCode.INVALID_PARAMETER, "로드맵 단계 정보 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private record RoadmapStepPayload(
+            String stage,
+            String goal,
+            List<String> topics,
+            List<String> outputs
+    ) {
     }
 
     private LocalDate toLocalDate(java.time.LocalDateTime dateTime) {

--- a/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
+++ b/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
@@ -80,10 +80,7 @@ public class CommunityPostService {
         CommunityPost post = getPostOrThrow(postId);
         post.increaseViewCount();
 
-        List<CommunityCommentResponse> comments = communityCommentRepository.findAllByPostIdOrderByThread(postId)
-                .stream()
-                .map(this::toCommentResponse)
-                .toList();
+        List<CommunityCommentResponse> comments = getComments(postId);
 
         boolean liked = currentUserId != null && communityPostLikeRepository.existsByPost_IdAndUser_Id(postId, currentUserId);
 
@@ -194,6 +191,15 @@ public class CommunityPostService {
         );
 
         return toCommentResponse(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommunityCommentResponse> getComments(Long postId) {
+        getPostOrThrow(postId);
+        return communityCommentRepository.findAllByPostIdOrderByThread(postId)
+                .stream()
+                .map(this::toCommentResponse)
+                .toList();
     }
 
     private CommunityPost getPostOrThrow(Long postId) {

--- a/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
+++ b/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
@@ -13,6 +13,7 @@ import com.roddy.domain.community.dto.response.CreateCommunityPostResponse;
 import com.roddy.domain.community.dto.response.ReportPostResponse;
 import com.roddy.domain.community.dto.response.TogglePostLikeResponse;
 import com.roddy.domain.community.entity.CommunityComment;
+import com.roddy.domain.community.entity.CommunityCommentReport;
 import com.roddy.domain.community.entity.CommunityInterviewPostDetail;
 import com.roddy.domain.community.entity.CommunityPost;
 import com.roddy.domain.community.entity.CommunityPostImage;
@@ -20,6 +21,7 @@ import com.roddy.domain.community.entity.CommunityPostLike;
 import com.roddy.domain.community.entity.CommunityPostReport;
 import com.roddy.domain.community.entity.CommunityRoadmapPostDetail;
 import com.roddy.domain.community.repository.CommunityCommentRepository;
+import com.roddy.domain.community.repository.CommunityCommentReportRepository;
 import com.roddy.domain.community.repository.CommunityPostLikeRepository;
 import com.roddy.domain.community.repository.CommunityPostReportRepository;
 import com.roddy.domain.community.repository.CommunityPostRepository;
@@ -54,6 +56,7 @@ public class CommunityPostService {
 
     private final CommunityPostRepository communityPostRepository;
     private final CommunityCommentRepository communityCommentRepository;
+    private final CommunityCommentReportRepository communityCommentReportRepository;
     private final CommunityPostLikeRepository communityPostLikeRepository;
     private final CommunityPostReportRepository communityPostReportRepository;
     private final UserRepository userRepository;
@@ -202,9 +205,41 @@ public class CommunityPostService {
                 .toList();
     }
 
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
+        CommunityComment comment = getCommentOrThrow(commentId);
+        if (!comment.isAuthor(userId)) {
+            throw new GeneralException(GeneralErrorCode.COMMUNITY_COMMENT_DELETE_FORBIDDEN);
+        }
+        communityCommentRepository.delete(comment);
+    }
+
+    @Transactional
+    public ReportPostResponse reportComment(Long commentId, Long userId) {
+        CommunityComment comment = getCommentOrThrow(commentId);
+        User user = getUserOrThrow(userId);
+
+        if (communityCommentReportRepository.existsByComment_IdAndUser_Id(commentId, userId)) {
+            throw new GeneralException(GeneralErrorCode.COMMUNITY_COMMENT_ALREADY_REPORTED);
+        }
+
+        try {
+            communityCommentReportRepository.save(CommunityCommentReport.create(comment, user, null));
+        } catch (DataIntegrityViolationException exception) {
+            throw new GeneralException(GeneralErrorCode.COMMUNITY_COMMENT_ALREADY_REPORTED);
+        }
+
+        return new ReportPostResponse(true);
+    }
+
     private CommunityPost getPostOrThrow(Long postId) {
         return communityPostRepository.findDetailById(postId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.COMMUNITY_POST_NOT_FOUND));
+    }
+
+    private CommunityComment getCommentOrThrow(Long commentId) {
+        return communityCommentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.COMMUNITY_COMMENT_NOT_FOUND));
     }
 
     private User getUserOrThrow(Long userId) {

--- a/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
+++ b/roddy/src/main/java/com/roddy/domain/community/service/CommunityPostService.java
@@ -12,6 +12,7 @@ import com.roddy.domain.community.dto.response.CommunityCommentResponse;
 import com.roddy.domain.community.dto.response.CommunityPostDetailResponse;
 import com.roddy.domain.community.dto.response.CommunityPostListItemResponse;
 import com.roddy.domain.community.dto.response.CommunityPostListResponse;
+import com.roddy.domain.community.dto.response.CommunityRoadmapStepResponse;
 import com.roddy.domain.community.dto.response.CreateCommunityPostResponse;
 import com.roddy.domain.community.dto.response.ReportPostResponse;
 import com.roddy.domain.community.dto.response.TogglePostLikeResponse;
@@ -45,9 +46,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -95,20 +96,36 @@ public class CommunityPostService {
 
         return new CommunityPostDetailResponse(
                 post.getId(),
-                post.getPostCategory().name(),
-                post.getPostCategory().getDisplayName(),
-                post.getJobCategory().name(),
-                post.getJobCategory().getDisplayName(),
+                toPostType(post),
+                toTagKey(post),
+                buildTags(post),
                 post.getTitle(),
                 post.getContent(),
                 post.getAuthor().getNickname(),
-                toLocalDate(post.getCreatedAt()),
+                post.getCreatedAt(),
                 post.getViewCount(),
                 post.getLikeCount(),
+                getCommentCount(post.getId()),
                 liked,
+                createExcerpt(post.getContent()),
+                extractRoadmapId(post),
+                extractRoadmapTitle(post),
+                extractRoadmapSummary(post),
+                extractRoadmapTargetJob(post),
+                extractRoadmapTargetCompany(post),
+                extractRecommendedSkills(post),
+                extractRoadmapSteps(post),
+                extractRoadmapDescription(post),
+                extractInterviewSubtype(post),
                 extractCompany(post),
                 extractJobRole(post),
+                extractPreparationPeriod(post),
                 extractTechStacks(post),
+                extractProcessSummary(post),
+                extractBackground(post),
+                extractPreparationProcess(post),
+                extractExperienceDetail(post),
+                extractAdvice(post),
                 post.getImages().stream().map(CommunityPostImage::getImageUrl).toList(),
                 comments
         );
@@ -256,29 +273,46 @@ public class CommunityPostService {
     private CommunityPostListItemResponse toListItemResponse(CommunityPost post) {
         return new CommunityPostListItemResponse(
                 post.getId(),
-                post.getPostCategory().name(),
-                post.getPostCategory().getDisplayName(),
-                post.getJobCategory().name(),
-                post.getJobCategory().getDisplayName(),
+                toPostType(post),
+                toTagKey(post),
+                buildTags(post),
                 post.getTitle(),
                 post.getAuthor().getNickname(),
-                toLocalDate(post.getCreatedAt()),
+                post.getCreatedAt(),
                 post.getViewCount(),
                 post.getLikeCount(),
+                getCommentCount(post.getId()),
+                createExcerpt(post.getContent()),
+                post.getContent(),
+                extractRoadmapId(post),
+                extractRoadmapTitle(post),
+                extractRoadmapSummary(post),
+                extractRoadmapTargetJob(post),
+                extractRoadmapTargetCompany(post),
+                extractRecommendedSkills(post),
+                extractRoadmapSteps(post),
+                extractRoadmapDescription(post),
+                extractInterviewSubtype(post),
                 extractCompany(post),
                 extractJobRole(post),
-                extractTechStacks(post)
+                extractPreparationPeriod(post),
+                extractTechStacks(post),
+                extractProcessSummary(post),
+                extractBackground(post),
+                extractPreparationProcess(post),
+                extractExperienceDetail(post),
+                extractAdvice(post)
         );
     }
 
     private CommunityCommentResponse toCommentResponse(CommunityComment comment) {
         return new CommunityCommentResponse(
                 comment.getId(),
-                comment.getContent(),
                 comment.getAuthor().getNickname(),
+                comment.getContent(),
                 comment.getParentComment() == null ? null : comment.getParentComment().getId(),
                 comment.getDepth(),
-                toLocalDate(comment.getCreatedAt())
+                comment.getCreatedAt()
         );
     }
 
@@ -353,6 +387,10 @@ public class CommunityPostService {
         return null;
     }
 
+    private String extractPreparationPeriod(CommunityPost post) {
+        return post.getInterviewDetail() == null ? null : post.getInterviewDetail().getPreparationPeriod();
+    }
+
     private List<String> extractTechStacks(CommunityPost post) {
         if (post.getRoadmapDetail() != null) {
             return new ArrayList<>(post.getRoadmapDetail().getRecommendedSkills());
@@ -361,6 +399,136 @@ public class CommunityPostService {
             return new ArrayList<>(post.getInterviewDetail().getTechStacks());
         }
         return List.of();
+    }
+
+    private String extractProcessSummary(CommunityPost post) {
+        return post.getInterviewDetail() == null ? null : post.getInterviewDetail().getProcessSummary();
+    }
+
+    private String extractBackground(CommunityPost post) {
+        return post.getInterviewDetail() == null ? null : post.getInterviewDetail().getBackground();
+    }
+
+    private String extractPreparationProcess(CommunityPost post) {
+        return post.getInterviewDetail() == null ? null : post.getInterviewDetail().getPreparationProcess();
+    }
+
+    private String extractExperienceDetail(CommunityPost post) {
+        return post.getInterviewDetail() == null ? null : post.getInterviewDetail().getExperienceDetail();
+    }
+
+    private String extractAdvice(CommunityPost post) {
+        return post.getInterviewDetail() == null ? null : post.getInterviewDetail().getAdvice();
+    }
+
+    private String extractRoadmapId(CommunityPost post) {
+        return post.getRoadmapDetail() == null ? null : post.getRoadmapDetail().getRoadmapId();
+    }
+
+    private String extractRoadmapTitle(CommunityPost post) {
+        return post.getRoadmapDetail() == null ? null : post.getRoadmapDetail().getRoadmapTitle();
+    }
+
+    private String extractRoadmapSummary(CommunityPost post) {
+        return post.getRoadmapDetail() == null ? null : post.getRoadmapDetail().getSummary();
+    }
+
+    private String extractRoadmapTargetJob(CommunityPost post) {
+        return post.getRoadmapDetail() == null ? null : post.getRoadmapDetail().getTargetJob();
+    }
+
+    private String extractRoadmapTargetCompany(CommunityPost post) {
+        return post.getRoadmapDetail() == null ? null : post.getRoadmapDetail().getTargetCompany();
+    }
+
+    private List<String> extractRecommendedSkills(CommunityPost post) {
+        return post.getRoadmapDetail() == null ? List.of() : new ArrayList<>(post.getRoadmapDetail().getRecommendedSkills());
+    }
+
+    private List<CommunityRoadmapStepResponse> extractRoadmapSteps(CommunityPost post) {
+        if (post.getRoadmapDetail() == null) {
+            return List.of();
+        }
+
+        return post.getRoadmapDetail().getRoadmapSteps().stream()
+                .map(step -> new CommunityRoadmapStepResponse(
+                        step.getStage(),
+                        step.getGoal(),
+                        new ArrayList<>(step.getTopics()),
+                        new ArrayList<>(step.getOutputs())
+                ))
+                .toList();
+    }
+
+    private String extractRoadmapDescription(CommunityPost post) {
+        return post.getRoadmapDetail() == null ? null : post.getRoadmapDetail().getDescription();
+    }
+
+    private String extractInterviewSubtype(CommunityPost post) {
+        if (post.getInterviewDetail() == null) {
+            return null;
+        }
+        return post.getInterviewDetail().getSubtype() == CommunityInterviewSubtype.INCUMBENT ? "incumbent" : "accepted";
+    }
+
+    private String toPostType(CommunityPost post) {
+        if (post.isRoadmapPost()) {
+            return "roadmap";
+        }
+        if (post.isInterviewPost()) {
+            return "interview";
+        }
+        return "general";
+    }
+
+    private String toTagKey(CommunityPost post) {
+        return switch (post.getJobCategory()) {
+            case B2C -> "b2c";
+            case FINTECH -> "fintech";
+            case B2B -> "b2b";
+            case INFRA_DEVOPS -> "infra-devops";
+            case GENERALIST -> "generalist";
+        };
+    }
+
+    private List<String> buildTags(CommunityPost post) {
+        Set<String> tags = new LinkedHashSet<>(post.getTags());
+
+        if (post.isGeneralPost()) {
+            tags.add(post.getPostCategory().getDisplayName());
+        }
+
+        if (post.getRoadmapDetail() != null) {
+            tags.add(post.getRoadmapDetail().getRoadmapTitle());
+            tags.add(post.getRoadmapDetail().getTargetJob());
+            if (post.getRoadmapDetail().getTargetCompany() != null) {
+                tags.add(post.getRoadmapDetail().getTargetCompany());
+            }
+            tags.addAll(post.getRoadmapDetail().getRecommendedSkills());
+        }
+
+        if (post.getInterviewDetail() != null) {
+            tags.add(post.getInterviewDetail().getSubtype().getDisplayName());
+            tags.add(post.getInterviewDetail().getCompany());
+            tags.add(post.getInterviewDetail().getJobRole());
+            tags.addAll(post.getInterviewDetail().getTechStacks());
+        }
+
+        return tags.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .toList();
+    }
+
+    private String createExcerpt(String content) {
+        if (!hasText(content)) {
+            return "";
+        }
+        String trimmed = content.trim();
+        return trimmed.length() <= 120 ? trimmed : trimmed.substring(0, 120);
+    }
+
+    private int getCommentCount(Long postId) {
+        return Math.toIntExact(communityCommentRepository.countByPost_Id(postId));
     }
 
     private String defaultIfBlank(String value, String defaultValue) {
@@ -448,10 +616,6 @@ public class CommunityPostService {
             List<String> topics,
             List<String> outputs
     ) {
-    }
-
-    private LocalDate toLocalDate(java.time.LocalDateTime dateTime) {
-        return dateTime == null ? null : dateTime.toLocalDate();
     }
 
     private List<MultipartFile> safeImages(List<MultipartFile> images) {

--- a/roddy/src/main/java/com/roddy/domain/mypage/entity/DesiredCompany.java
+++ b/roddy/src/main/java/com/roddy/domain/mypage/entity/DesiredCompany.java
@@ -1,4 +1,5 @@
-package com.roddy.domain;
+package com.roddy.domain.mypage.entity;
+
 import com.roddy.domain.auth.entity.User;
 import com.roddy.domain.enums.DesiredJob;
 import jakarta.persistence.*;

--- a/roddy/src/main/java/com/roddy/domain/mypage/repository/DesiredCompanyRepository.java
+++ b/roddy/src/main/java/com/roddy/domain/mypage/repository/DesiredCompanyRepository.java
@@ -1,6 +1,6 @@
-package com.roddy.domain.repository;
+package com.roddy.domain.mypage.repository;
 
-import com.roddy.domain.DesiredCompany;
+import com.roddy.domain.mypage.entity.DesiredCompany;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/roddy/src/main/java/com/roddy/domain/mypage/service/MyPageService.java
+++ b/roddy/src/main/java/com/roddy/domain/mypage/service/MyPageService.java
@@ -1,11 +1,11 @@
 package com.roddy.domain.mypage.service;
 
-import com.roddy.domain.DesiredCompany;
 import com.roddy.domain.auth.entity.User;
 import com.roddy.domain.auth.repository.UserRepository;
+import com.roddy.domain.mypage.entity.DesiredCompany;
 import com.roddy.domain.mypage.dto.request.MyPageProfileUpdateRequest;
 import com.roddy.domain.mypage.dto.response.MyPageProfileResponse;
-import com.roddy.domain.repository.DesiredCompanyRepository;
+import com.roddy.domain.mypage.repository.DesiredCompanyRepository;
 import com.roddy.global.apiPayload.code.GeneralErrorCode;
 import com.roddy.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;

--- a/roddy/src/main/java/com/roddy/domain/onboarding/service/OnboardingService.java
+++ b/roddy/src/main/java/com/roddy/domain/onboarding/service/OnboardingService.java
@@ -1,15 +1,15 @@
 package com.roddy.domain.onboarding.service;
 
-import com.roddy.domain.DesiredCompany;
 import com.roddy.domain.auth.entity.User;
 import com.roddy.domain.auth.repository.UserRepository;
 import com.roddy.domain.enums.DesiredJob;
 import com.roddy.domain.enums.ExperienceLevel;
+import com.roddy.domain.mypage.entity.DesiredCompany;
+import com.roddy.domain.mypage.repository.DesiredCompanyRepository;
 import com.roddy.domain.onboarding.dto.request.OnboardingProfileRequest;
 import com.roddy.domain.onboarding.dto.request.PortfolioPresignRequest;
 import com.roddy.domain.onboarding.dto.response.OnboardingProfileResponse;
 import com.roddy.domain.onboarding.dto.response.PortfolioPresignResponse;
-import com.roddy.domain.repository.DesiredCompanyRepository;
 import com.roddy.global.config.s3.S3ObjectUrlService;
 import com.roddy.global.apiPayload.code.GeneralErrorCode;
 import com.roddy.global.apiPayload.exception.GeneralException;

--- a/roddy/src/main/java/com/roddy/global/apiPayload/code/GeneralErrorCode.java
+++ b/roddy/src/main/java/com/roddy/global/apiPayload/code/GeneralErrorCode.java
@@ -37,6 +37,8 @@ public enum GeneralErrorCode implements BaseErrorCode {
     COMMUNITY_POST_ALREADY_REPORTED(HttpStatus.CONFLICT, "COMMUNITY_4091", "이미 신고한 게시글입니다."),
     COMMUNITY_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMUNITY_4042", "댓글을 찾을 수 없습니다."),
     COMMUNITY_COMMENT_PARENT_INVALID(HttpStatus.BAD_REQUEST, "COMMUNITY_4001", "대댓글은 최상위 댓글에만 작성할 수 있습니다."),
+    COMMUNITY_COMMENT_ALREADY_REPORTED(HttpStatus.CONFLICT, "COMMUNITY_4092", "이미 신고한 댓글입니다."),
+    COMMUNITY_COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMUNITY_4031", "본인 댓글만 삭제할 수 있습니다."),
 
     // 스터디 에러
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_4041", "스터디 모집글을 찾을 수 없습니다."),

--- a/roddy/src/main/java/com/roddy/global/apiPayload/code/GeneralErrorCode.java
+++ b/roddy/src/main/java/com/roddy/global/apiPayload/code/GeneralErrorCode.java
@@ -35,6 +35,8 @@ public enum GeneralErrorCode implements BaseErrorCode {
     // 커뮤니티 에러
     COMMUNITY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMUNITY_4041", "게시글을 찾을 수 없습니다."),
     COMMUNITY_POST_ALREADY_REPORTED(HttpStatus.CONFLICT, "COMMUNITY_4091", "이미 신고한 게시글입니다."),
+    COMMUNITY_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMUNITY_4042", "댓글을 찾을 수 없습니다."),
+    COMMUNITY_COMMENT_PARENT_INVALID(HttpStatus.BAD_REQUEST, "COMMUNITY_4001", "대댓글은 최상위 댓글에만 작성할 수 있습니다."),
 
     // 스터디 에러
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_4041", "스터디 모집글을 찾을 수 없습니다."),

--- a/roddy/src/main/java/com/roddy/global/config/SecurityConfig.java
+++ b/roddy/src/main/java/com/roddy/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                 .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                 .requestMatchers("/api/onboarding/github/callback").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/community/posts", "/api/community/posts/*").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/community/posts", "/api/community/posts/*", "/api/community/posts/*/comments").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/studies", "/api/studies/*").permitAll()
                 .anyRequest().authenticated()
         );

--- a/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
@@ -11,6 +11,7 @@ import com.roddy.domain.community.enums.CommunityJobCategory;
 import com.roddy.domain.community.enums.CommunityInterviewSubtype;
 import com.roddy.domain.community.enums.CommunityPostCategory;
 import com.roddy.domain.community.repository.CommunityCommentRepository;
+import com.roddy.domain.community.repository.CommunityCommentReportRepository;
 import com.roddy.domain.community.repository.CommunityPostImageRepository;
 import com.roddy.domain.community.repository.CommunityPostLikeRepository;
 import com.roddy.domain.community.repository.CommunityPostReportRepository;
@@ -38,6 +39,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -69,6 +71,9 @@ class CommunityPostControllerTest {
     private CommunityCommentRepository communityCommentRepository;
 
     @Autowired
+    private CommunityCommentReportRepository communityCommentReportRepository;
+
+    @Autowired
     private CommunityPostImageRepository communityPostImageRepository;
 
     @Autowired
@@ -88,6 +93,7 @@ class CommunityPostControllerTest {
 
         communityPostLikeRepository.deleteAll();
         communityPostReportRepository.deleteAll();
+        communityCommentReportRepository.deleteAll();
         communityCommentRepository.deleteAll();
         communityPostImageRepository.deleteAll();
         communityPostRepository.deleteAll();
@@ -432,6 +438,79 @@ class CommunityPostControllerTest {
                 .andExpect(jsonPath("$.result[1].content").value("첫 댓글의 답글"))
                 .andExpect(jsonPath("$.result[1].depth").value(1))
                 .andExpect(jsonPath("$.result[1].parentId").value(rootCommentId));
+    }
+
+    @Test
+    void 본인_댓글_삭제_성공() throws Exception {
+        User user = saveUser("comment-delete@example.com", "댓글삭제사용자");
+        CommunityPost post = savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2B, "댓글 삭제 글", null, null, "Java");
+
+        String rootResponse = mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("삭제할 댓글", null))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long commentId = objectMapper.readTree(rootResponse).path("result").path("id").asLong();
+
+        mockMvc.perform(delete("/api/community/comments/{commentId}", commentId)
+                        .with(user(new UserDetailsImpl(user))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        mockMvc.perform(get("/api/community/posts/{postId}/comments", post.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.length()").value(0));
+    }
+
+    @Test
+    void 타인_댓글_삭제는_실패한다() throws Exception {
+        User writer = saveUser("comment-owner@example.com", "댓글주인");
+        User other = saveUser("comment-other@example.com", "다른사용자");
+        CommunityPost post = savePost(writer, CommunityPostCategory.FREE, CommunityJobCategory.B2B, "댓글 권한 글", null, null, "Java");
+
+        String rootResponse = mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(writer)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("삭제 불가 댓글", null))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long commentId = objectMapper.readTree(rootResponse).path("result").path("id").asLong();
+
+        mockMvc.perform(delete("/api/community/comments/{commentId}", commentId)
+                        .with(user(new UserDetailsImpl(other))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    void 댓글_중복_신고_방지() throws Exception {
+        User user = saveUser("comment-report@example.com", "댓글신고사용자");
+        CommunityPost post = savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2B, "댓글 신고 글", null, null, "Java");
+
+        String rootResponse = mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("신고 대상 댓글", null))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long commentId = objectMapper.readTree(rootResponse).path("result").path("id").asLong();
+
+        mockMvc.perform(post("/api/community/comments/{commentId}/report", commentId)
+                        .with(user(new UserDetailsImpl(user))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.reported").value(true));
+
+        mockMvc.perform(post("/api/community/comments/{commentId}/report", commentId)
+                        .with(user(new UserDetailsImpl(user))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.isSuccess").value(false));
     }
 
     @Test

--- a/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
@@ -127,6 +127,44 @@ class CommunityPostControllerTest {
     }
 
     @Test
+    void 인터뷰_게시글_작성_성공() throws Exception {
+        User user = saveUser("interview-writer@example.com", "인터뷰작성자");
+
+        mockMvc.perform(multipart("/api/community/posts")
+                        .param("postCategory", "PASS_REVIEW_INTERVIEW")
+                        .param("jobCategory", "FINTECH")
+                        .param("title", "토스 백엔드 합격 후기")
+                        .param("content", "전체 후기 본문")
+                        .param("company", "토스")
+                        .param("jobRole", "백엔드")
+                        .param("preparationPeriod", "3개월")
+                        .param("techStacks", "Java", "Spring")
+                        .param("processSummary", "서류-과제-면접")
+                        .param("background", "백엔드 전환 준비")
+                        .param("preparationProcess", "CS와 프로젝트 정리")
+                        .param("experienceDetail", "면접에서 트랜잭션 질문을 받음")
+                        .param("advice", "프로젝트 선택 근거를 분명히 준비")
+                        .with(user(new UserDetailsImpl(user))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").isNumber());
+    }
+
+    @Test
+    void 인터뷰_게시글은_필수_상세값이_없으면_실패한다() throws Exception {
+        User user = saveUser("interview-invalid@example.com", "인터뷰검증작성자");
+
+        mockMvc.perform(multipart("/api/community/posts")
+                        .param("postCategory", "PASS_REVIEW_INTERVIEW")
+                        .param("jobCategory", "FINTECH")
+                        .param("title", "필수값 없는 인터뷰 글")
+                        .param("content", "본문")
+                        .param("company", "토스")
+                        .with(user(new UserDetailsImpl(user))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
     void 제목이_비어있으면_실패() throws Exception {
         User user = saveUser("writer2@example.com", "작성자2");
 

--- a/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
@@ -345,6 +345,96 @@ class CommunityPostControllerTest {
     }
 
     @Test
+    void 대댓글_작성_성공() throws Exception {
+        User user = saveUser("reply@example.com", "답글사용자");
+        CommunityPost post = savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2B, "답글 글", null, null, "Java");
+
+        String rootResponse = mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("루트 댓글", null))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        Long parentCommentId = objectMapper.readTree(rootResponse).path("result").path("id").asLong();
+
+        mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("대댓글", parentCommentId))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.content").value("대댓글"))
+                .andExpect(jsonPath("$.result.parentId").value(parentCommentId))
+                .andExpect(jsonPath("$.result.depth").value(1));
+    }
+
+    @Test
+    void 대댓글에는_대댓글을_달수없다() throws Exception {
+        User user = saveUser("reply-chain@example.com", "답글체인사용자");
+        CommunityPost post = savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2B, "답글 검증 글", null, null, "Java");
+
+        String rootResponse = mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("루트 댓글", null))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long rootCommentId = objectMapper.readTree(rootResponse).path("result").path("id").asLong();
+
+        String replyResponse = mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("대댓글", rootCommentId))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long replyCommentId = objectMapper.readTree(replyResponse).path("result").path("id").asLong();
+
+        mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("대댓글의 대댓글", replyCommentId))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    void 댓글_목록_조회시_대댓글_계층을_반환한다() throws Exception {
+        User user = saveUser("comment-list@example.com", "댓글목록사용자");
+        CommunityPost post = savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2B, "댓글 목록 글", null, null, "Java");
+
+        String rootResponse = mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("첫 댓글", null))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long rootCommentId = objectMapper.readTree(rootResponse).path("result").path("id").asLong();
+
+        mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
+                        .with(user(new UserDetailsImpl(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CommentRequest("첫 댓글의 답글", rootCommentId))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/community/posts/{postId}/comments", post.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.length()").value(2))
+                .andExpect(jsonPath("$.result[0].content").value("첫 댓글"))
+                .andExpect(jsonPath("$.result[0].depth").value(0))
+                .andExpect(jsonPath("$.result[1].content").value("첫 댓글의 답글"))
+                .andExpect(jsonPath("$.result[1].depth").value(1))
+                .andExpect(jsonPath("$.result[1].parentId").value(rootCommentId));
+    }
+
+    @Test
     void 비로그인_사용자는_댓글_작성에_실패한다() throws Exception {
         User user = saveUser("anonymous@example.com", "익명대상");
         CommunityPost post = savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.INFRA_DEVOPS, "인증 글", "당근", "DevOps", "Docker");

--- a/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
@@ -32,8 +32,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -162,6 +165,101 @@ class CommunityPostControllerTest {
                         .with(user(new UserDetailsImpl(user))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    void 로드맵_생성후_상세조회시_프론트_확장_필드가_반영된다() throws Exception {
+        User user = saveUser("roadmap-detail@example.com", "로드맵작성자");
+
+        String createResponse = mockMvc.perform(multipart("/api/community/posts")
+                        .param("postCategory", "ROADMAP")
+                        .param("jobCategory", "B2C")
+                        .param("title", "백엔드 로드맵")
+                        .param("content", "로드맵 본문")
+                        .param("tags", "java", "spring")
+                        .param("roadmapId", "rm-101")
+                        .param("roadmapTitle", "주니어 백엔드 로드맵")
+                        .param("summary", "핵심 요약")
+                        .param("description", "상세 설명")
+                        .param("targetJob", "백엔드")
+                        .param("targetCompany", "토스")
+                        .param("recommendedSkills", "Java", "Spring")
+                        .param("roadmapStepsJson", objectMapper.writeValueAsString(List.of(
+                                Map.of(
+                                        "stage", "1단계",
+                                        "goal", "기초 다지기",
+                                        "topics", List.of("Java", "OOP"),
+                                        "outputs", List.of("미니 프로젝트")
+                                )
+                        )))
+                        .with(user(new UserDetailsImpl(user))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        Long postId = extractResultId(createResponse);
+
+        mockMvc.perform(get("/api/community/posts/{postId}", postId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.type").value("roadmap"))
+                .andExpect(jsonPath("$.result.tag").value("b2c"))
+                .andExpect(jsonPath("$.result.tags", hasItem("java")))
+                .andExpect(jsonPath("$.result.roadmapId").value("rm-101"))
+                .andExpect(jsonPath("$.result.roadmapTitle").value("주니어 백엔드 로드맵"))
+                .andExpect(jsonPath("$.result.summary").value("핵심 요약"))
+                .andExpect(jsonPath("$.result.targetJob").value("백엔드"))
+                .andExpect(jsonPath("$.result.targetCompany").value("토스"))
+                .andExpect(jsonPath("$.result.recommendedSkills[0]").value("Java"))
+                .andExpect(jsonPath("$.result.roadmapSteps[0].stage").value("1단계"))
+                .andExpect(jsonPath("$.result.roadmapSteps[0].topics[0]").value("Java"))
+                .andExpect(jsonPath("$.result.description").value("상세 설명"))
+                .andExpect(jsonPath("$.result.commentCount").value(0))
+                .andExpect(jsonPath("$.result.excerpt").value("로드맵 본문"));
+    }
+
+    @Test
+    void 인터뷰_생성후_상세조회시_프론트_확장_필드가_반영된다() throws Exception {
+        User user = saveUser("interview-detail@example.com", "인터뷰상세작성자");
+
+        String createResponse = mockMvc.perform(multipart("/api/community/posts")
+                        .param("postCategory", "PASS_REVIEW_INTERVIEW")
+                        .param("jobCategory", "FINTECH")
+                        .param("title", "토스 백엔드 최종합격")
+                        .param("content", "인터뷰 전체 본문")
+                        .param("tags", "합격", "후기")
+                        .param("interviewSubtype", "INCUMBENT")
+                        .param("company", "토스")
+                        .param("jobRole", "백엔드")
+                        .param("preparationPeriod", "4개월")
+                        .param("techStacks", "Java", "Spring")
+                        .param("processSummary", "서류-과제-최종면접")
+                        .param("background", "이직 준비 중")
+                        .param("preparationProcess", "CS와 프로젝트 정리")
+                        .param("experienceDetail", "트랜잭션과 분산락 질문이 나왔다")
+                        .param("advice", "실제 장애 대응 경험을 정리해두면 좋다")
+                        .with(user(new UserDetailsImpl(user))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        Long postId = extractResultId(createResponse);
+
+        mockMvc.perform(get("/api/community/posts/{postId}", postId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.type").value("interview"))
+                .andExpect(jsonPath("$.result.tag").value("fintech"))
+                .andExpect(jsonPath("$.result.subtype").value("incumbent"))
+                .andExpect(jsonPath("$.result.company").value("토스"))
+                .andExpect(jsonPath("$.result.jobRole").value("백엔드"))
+                .andExpect(jsonPath("$.result.preparationPeriod").value("4개월"))
+                .andExpect(jsonPath("$.result.techStacks[0]").value("Java"))
+                .andExpect(jsonPath("$.result.processSummary").value("서류-과제-최종면접"))
+                .andExpect(jsonPath("$.result.background").value("이직 준비 중"))
+                .andExpect(jsonPath("$.result.preparationProcess").value("CS와 프로젝트 정리"))
+                .andExpect(jsonPath("$.result.experienceDetail").value("트랜잭션과 분산락 질문이 나왔다"))
+                .andExpect(jsonPath("$.result.advice").value("실제 장애 대응 경험을 정리해두면 좋다"));
     }
 
     @Test
@@ -624,6 +722,10 @@ class CommunityPostControllerTest {
         }
 
         return communityPostRepository.save(post);
+    }
+
+    private Long extractResultId(String response) throws Exception {
+        return objectMapper.readTree(response).path("result").path("id").asLong();
     }
 
     private record CommentRequest(String content, Long parentCommentId) {

--- a/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
@@ -3,8 +3,12 @@ package com.roddy.domain.community.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.roddy.domain.auth.entity.User;
 import com.roddy.domain.auth.repository.UserRepository;
+import com.roddy.domain.auth.service.SocialAuthService;
+import com.roddy.domain.community.entity.CommunityInterviewPostDetail;
 import com.roddy.domain.community.entity.CommunityPost;
+import com.roddy.domain.community.entity.CommunityRoadmapPostDetail;
 import com.roddy.domain.community.enums.CommunityJobCategory;
+import com.roddy.domain.community.enums.CommunityInterviewSubtype;
 import com.roddy.domain.community.enums.CommunityPostCategory;
 import com.roddy.domain.community.repository.CommunityCommentRepository;
 import com.roddy.domain.community.repository.CommunityPostImageRepository;
@@ -72,6 +76,9 @@ class CommunityPostControllerTest {
 
     @MockitoBean
     private S3Uploader s3Uploader;
+
+    @MockitoBean
+    private SocialAuthService socialAuthService;
 
     @BeforeEach
     void setUp() {
@@ -193,8 +200,8 @@ class CommunityPostControllerTest {
     @Test
     void keyword로_company_검색_성공() throws Exception {
         User user = saveUser("keyword-company@example.com", "회사검색작성자");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Java");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "다른 질문", "네이버", "백엔드", "Java");
+        savePost(user, CommunityPostCategory.ROADMAP, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Java");
+        savePost(user, CommunityPostCategory.ROADMAP, CommunityJobCategory.B2C, "다른 질문", "네이버", "백엔드", "Java");
 
         mockMvc.perform(get("/api/community/posts").param("keyword", "카카오"))
                 .andExpect(status().isOk())
@@ -205,8 +212,8 @@ class CommunityPostControllerTest {
     @Test
     void keyword로_position_검색_성공() throws Exception {
         User user = saveUser("keyword-position@example.com", "직무검색작성자");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "질문", "카카오", "데이터 엔지니어", "Python");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "다른 질문", "카카오", "백엔드", "Java");
+        savePost(user, CommunityPostCategory.PASS_REVIEW_INTERVIEW, CommunityJobCategory.B2C, "질문", "카카오", "데이터 엔지니어", "Python");
+        savePost(user, CommunityPostCategory.PASS_REVIEW_INTERVIEW, CommunityJobCategory.B2C, "다른 질문", "카카오", "백엔드", "Java");
 
         mockMvc.perform(get("/api/community/posts").param("keyword", "데이터"))
                 .andExpect(status().isOk())
@@ -217,8 +224,8 @@ class CommunityPostControllerTest {
     @Test
     void keyword로_techStacks_검색_성공() throws Exception {
         User user = saveUser("keyword-tech@example.com", "스택검색작성자");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Spring");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "다른 질문", "카카오", "백엔드", "React");
+        savePost(user, CommunityPostCategory.ROADMAP, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Spring");
+        savePost(user, CommunityPostCategory.PASS_REVIEW_INTERVIEW, CommunityJobCategory.B2C, "다른 질문", "카카오", "백엔드", "React");
 
         mockMvc.perform(get("/api/community/posts").param("keyword", "spring"))
                 .andExpect(status().isOk())
@@ -229,8 +236,8 @@ class CommunityPostControllerTest {
     @Test
     void company_필터_성공() throws Exception {
         User user = saveUser("company-filter@example.com", "회사필터작성자");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Spring");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "다른 질문", "토스", "백엔드", "Spring");
+        savePost(user, CommunityPostCategory.ROADMAP, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Spring");
+        savePost(user, CommunityPostCategory.ROADMAP, CommunityJobCategory.B2C, "다른 질문", "토스", "백엔드", "Spring");
 
         mockMvc.perform(get("/api/community/posts").param("company", "카카오"))
                 .andExpect(status().isOk())
@@ -241,10 +248,10 @@ class CommunityPostControllerTest {
     @Test
     void position_필터_성공() throws Exception {
         User user = saveUser("position-filter@example.com", "직무필터작성자");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Spring");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "다른 질문", "카카오", "프론트엔드", "React");
+        savePost(user, CommunityPostCategory.PASS_REVIEW_INTERVIEW, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Spring");
+        savePost(user, CommunityPostCategory.PASS_REVIEW_INTERVIEW, CommunityJobCategory.B2C, "다른 질문", "카카오", "프론트엔드", "React");
 
-        mockMvc.perform(get("/api/community/posts").param("position", "프론트"))
+        mockMvc.perform(get("/api/community/posts").param("jobRole", "프론트"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.posts.length()").value(1))
                 .andExpect(jsonPath("$.result.posts[0].position").value("프론트엔드"));
@@ -253,8 +260,8 @@ class CommunityPostControllerTest {
     @Test
     void techStack_필터_성공() throws Exception {
         User user = saveUser("tech-filter@example.com", "스택필터작성자");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Spring");
-        savePost(user, CommunityPostCategory.FREE, CommunityJobCategory.B2C, "다른 질문", "카카오", "백엔드", "Docker");
+        savePost(user, CommunityPostCategory.ROADMAP, CommunityJobCategory.B2C, "질문", "카카오", "백엔드", "Spring");
+        savePost(user, CommunityPostCategory.PASS_REVIEW_INTERVIEW, CommunityJobCategory.B2C, "다른 질문", "카카오", "백엔드", "Docker");
 
         mockMvc.perform(get("/api/community/posts").param("techStack", "Docker"))
                 .andExpect(status().isOk())
@@ -329,10 +336,12 @@ class CommunityPostControllerTest {
         mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
                         .with(user(new UserDetailsImpl(user)))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new CommentRequest("댓글 내용"))))
+                        .content(objectMapper.writeValueAsString(new CommentRequest("댓글 내용", null))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.content").value("댓글 내용"))
-                .andExpect(jsonPath("$.result.authorName").value("댓글사용자"));
+                .andExpect(jsonPath("$.result.authorName").value("댓글사용자"))
+                .andExpect(jsonPath("$.result.parentId").doesNotExist())
+                .andExpect(jsonPath("$.result.depth").value(0));
     }
 
     @Test
@@ -342,7 +351,7 @@ class CommunityPostControllerTest {
 
         mockMvc.perform(post("/api/community/posts/{postId}/comments", post.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new CommentRequest("댓글 내용"))))
+                        .content(objectMapper.writeValueAsString(new CommentRequest("댓글 내용", null))))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.isSuccess").value(false));
     }
@@ -369,20 +378,47 @@ class CommunityPostControllerTest {
             String position,
             String techStack
     ) {
-        return communityPostRepository.save(
-                CommunityPost.create(
-                        author,
-                        postCategory,
-                        jobCategory,
-                        title,
-                        title + " 본문",
-                        company,
-                        position,
-                        java.util.List.of(techStack)
-                )
+        CommunityPost post = CommunityPost.create(
+                author,
+                postCategory,
+                jobCategory,
+                title,
+                title + " 본문",
+                java.util.List.of()
         );
+
+        if (postCategory == CommunityPostCategory.ROADMAP) {
+            post.attachRoadmapDetail(CommunityRoadmapPostDetail.create(
+                    post,
+                    null,
+                    title,
+                    title + " 요약",
+                    title + " 설명",
+                    position,
+                    company,
+                    java.util.List.of(techStack)
+            ));
+        }
+
+        if (postCategory == CommunityPostCategory.PASS_REVIEW_INTERVIEW) {
+            post.attachInterviewDetail(CommunityInterviewPostDetail.create(
+                    post,
+                    CommunityInterviewSubtype.ACCEPTED,
+                    company == null ? "미입력" : company,
+                    position == null ? "미입력" : position,
+                    "2개월",
+                    java.util.List.of(techStack),
+                    title + " 프로세스",
+                    title + " 배경",
+                    title + " 준비 과정",
+                    title + " 상세",
+                    title + " 조언"
+            ));
+        }
+
+        return communityPostRepository.save(post);
     }
 
-    private record CommentRequest(String content) {
+    private record CommentRequest(String content, Long parentCommentId) {
     }
 }

--- a/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/community/controller/CommunityPostControllerTest.java
@@ -200,7 +200,7 @@ class CommunityPostControllerTest {
         mockMvc.perform(get("/api/community/posts").param("postCategory", "ROADMAP"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.posts.length()").value(1))
-                .andExpect(jsonPath("$.result.posts[0].postCategory").value("ROADMAP"));
+                .andExpect(jsonPath("$.result.posts[0].type").value("roadmap"));
     }
 
     @Test
@@ -212,7 +212,7 @@ class CommunityPostControllerTest {
         mockMvc.perform(get("/api/community/posts").param("jobCategory", "FINTECH"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.posts.length()").value(1))
-                .andExpect(jsonPath("$.result.posts[0].jobCategory").value("FINTECH"));
+                .andExpect(jsonPath("$.result.posts[0].tag").value("fintech"));
     }
 
     @Test
@@ -262,7 +262,7 @@ class CommunityPostControllerTest {
         mockMvc.perform(get("/api/community/posts").param("keyword", "데이터"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.posts.length()").value(1))
-                .andExpect(jsonPath("$.result.posts[0].position").value("데이터 엔지니어"));
+                .andExpect(jsonPath("$.result.posts[0].jobRole").value("데이터 엔지니어"));
     }
 
     @Test
@@ -298,7 +298,7 @@ class CommunityPostControllerTest {
         mockMvc.perform(get("/api/community/posts").param("jobRole", "프론트"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.posts.length()").value(1))
-                .andExpect(jsonPath("$.result.posts[0].position").value("프론트엔드"));
+                .andExpect(jsonPath("$.result.posts[0].jobRole").value("프론트엔드"));
     }
 
     @Test
@@ -320,12 +320,12 @@ class CommunityPostControllerTest {
 
         mockMvc.perform(get("/api/community/posts/{postId}", post.getId()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.viewCount").value(1))
-                .andExpect(jsonPath("$.result.postCategory").value("ROADMAP"))
-                .andExpect(jsonPath("$.result.jobCategory").value("FINTECH"))
+                .andExpect(jsonPath("$.result.views").value(1))
+                .andExpect(jsonPath("$.result.type").value("roadmap"))
+                .andExpect(jsonPath("$.result.tag").value("fintech"))
                 .andExpect(jsonPath("$.result.company").value("토스"))
-                .andExpect(jsonPath("$.result.position").value("백엔드"))
-                .andExpect(jsonPath("$.result.techStacks[0]").value("Spring"));
+                .andExpect(jsonPath("$.result.jobRole").value("백엔드"))
+                .andExpect(jsonPath("$.result.recommendedSkills[0]").value("Spring"));
     }
 
     @Test
@@ -383,7 +383,7 @@ class CommunityPostControllerTest {
                         .content(objectMapper.writeValueAsString(new CommentRequest("댓글 내용", null))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.content").value("댓글 내용"))
-                .andExpect(jsonPath("$.result.authorName").value("댓글사용자"))
+                .andExpect(jsonPath("$.result.author").value("댓글사용자"))
                 .andExpect(jsonPath("$.result.parentId").doesNotExist())
                 .andExpect(jsonPath("$.result.depth").value(0));
     }

--- a/roddy/src/test/java/com/roddy/domain/mypage/controller/MyPageControllerTest.java
+++ b/roddy/src/test/java/com/roddy/domain/mypage/controller/MyPageControllerTest.java
@@ -1,14 +1,15 @@
 package com.roddy.domain.mypage.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.roddy.domain.DesiredCompany;
 import com.roddy.domain.auth.entity.User;
 import com.roddy.domain.auth.repository.UserRepository;
+import com.roddy.domain.auth.service.SocialAuthService;
 import com.roddy.domain.enums.DesiredJob;
 import com.roddy.domain.enums.ExperienceLevel;
 import com.roddy.domain.enums.Role;
 import com.roddy.domain.enums.SocialType;
-import com.roddy.domain.repository.DesiredCompanyRepository;
+import com.roddy.domain.mypage.entity.DesiredCompany;
+import com.roddy.domain.mypage.repository.DesiredCompanyRepository;
 import com.roddy.global.security.UserDetailsImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,9 @@ class MyPageControllerTest {
 
     @MockitoBean
     private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private SocialAuthService socialAuthService;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [x] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요

커뮤니티 백엔드를 현재 프론트 스펙에 맞게 확장했습니다.

주요 변경 사항:
- CommunityPost 공통 필드와 타입별 상세 엔티티를 분리해 ROADMAP / PASS_REVIEW_INTERVIEW 확장 구조를 정리했습니다.
- 댓글을 parent-child 구조로 변경해 대댓글을 지원하고, 댓글 삭제/신고 API를 추가했습니다.
- 게시글 작성 API에서 로드맵/인터뷰 타입별 상세 필드 저장과 검증을 지원하도록 확장했습니다.
- 목록/상세 응답을 프론트가 사용하는 type, tag, tags, views, likes, commentCount, 로드맵/인터뷰 전용 필드 구조에 맞게 개편했습니다.
- 커뮤니티 컨트롤러 테스트에 로드맵/인터뷰 상세 응답 시나리오를 추가해 회귀를 방지했습니다.
- DesiredCompany와 DesiredCompanyRepository를 mypage 도메인 하위 패키지로 이동해 루트 domain/repository 구조를 정리했습니다.

테스트:
- bash ./gradlew compileJava
- bash ./gradlew test --tests com.roddy.domain.community.controller.CommunityPostControllerTest
- bash ./gradlew test --tests com.roddy.domain.mypage.controller.MyPageControllerTest

## 📸 작업 화면 스크린샷

백엔드 API 및 도메인 구조 변경 작업으로 별도 스크린샷은 없습니다.

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [ ] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ #19 ]
